### PR TITLE
STITCH-1041 Improve semantics of multiple logins

### DIFF
--- a/stitch/src/main/java/com/mongodb/stitch/android/auth/anonymous/AnonymousAuthProvider.java
+++ b/stitch/src/main/java/com/mongodb/stitch/android/auth/anonymous/AnonymousAuthProvider.java
@@ -9,7 +9,7 @@ import org.bson.Document;
  */
 public class AnonymousAuthProvider implements AuthProvider {
 
-    private static final String AUTH_TYPE = "anon-user";
+    public static final String AUTH_TYPE = "anon-user";
 
     @Override
     public String getType() {

--- a/stitch/src/main/java/com/mongodb/stitch/android/auth/apiKey/APIKeyProvider.java
+++ b/stitch/src/main/java/com/mongodb/stitch/android/auth/apiKey/APIKeyProvider.java
@@ -10,7 +10,7 @@ import org.bson.Document;
  * APIKeyProvider provides a way to authenticate using a generated apiKey.
  */
 public class APIKeyProvider implements AuthProvider {
-    private static final String AUTH_TYPE = "api-key";
+    public static final String AUTH_TYPE = "api-key";
 
     @NonNull
     private final String _key;

--- a/stitch/src/main/java/com/mongodb/stitch/android/auth/custom/CustomAuthProvider.java
+++ b/stitch/src/main/java/com/mongodb/stitch/android/auth/custom/CustomAuthProvider.java
@@ -8,7 +8,7 @@ import com.mongodb.stitch.android.auth.AuthProvider;
 import org.bson.Document;
 
 public class CustomAuthProvider implements AuthProvider {
-    private static final String AUTH_TYPE = "custom-token";
+    public static final String AUTH_TYPE = "custom-token";
 
     private static final String KEY_TOKEN = "token";
 

--- a/stitch/src/main/java/com/mongodb/stitch/android/auth/emailpass/EmailPasswordAuthProvider.java
+++ b/stitch/src/main/java/com/mongodb/stitch/android/auth/emailpass/EmailPasswordAuthProvider.java
@@ -11,7 +11,7 @@ import org.bson.Document;
  * EmailPasswordAuthProvider provides a way to authenticate using an email and password.
  */
 public class EmailPasswordAuthProvider implements AuthProvider {
-    private static final String AUTH_TYPE = "local-userpass";
+    public static final String AUTH_TYPE = "local-userpass";
 
     private static final String KEY_USERNAME = "username";
     private static final String KEY_EMAIL = "email";

--- a/stitch/src/main/java/com/mongodb/stitch/android/auth/oauth2/facebook/FacebookAuthProvider.java
+++ b/stitch/src/main/java/com/mongodb/stitch/android/auth/oauth2/facebook/FacebookAuthProvider.java
@@ -12,7 +12,7 @@ import static com.mongodb.stitch.android.auth.oauth2.OAuth2.Fields;
  */
 public class FacebookAuthProvider implements AuthProvider {
 
-    private static final String AUTH_TYPE = String.format("%s-facebook", OAuth2.AUTH_TYPE);
+    public static final String AUTH_TYPE = String.format("%s-facebook", OAuth2.AUTH_TYPE);
 
     private final String _accessToken;
 

--- a/stitch/src/main/java/com/mongodb/stitch/android/auth/oauth2/google/GoogleAuthProvider.java
+++ b/stitch/src/main/java/com/mongodb/stitch/android/auth/oauth2/google/GoogleAuthProvider.java
@@ -12,7 +12,7 @@ import static com.mongodb.stitch.android.auth.oauth2.OAuth2.Fields;
  */
 public class GoogleAuthProvider implements AuthProvider {
 
-    private static final String AUTH_TYPE = String.format("%s-google", OAuth2.AUTH_TYPE);
+    public static final String AUTH_TYPE = String.format("%s-google", OAuth2.AUTH_TYPE);
 
     private final String _authCode;
 


### PR DESCRIPTION
These are pretty much the exact same changes as iOS.

**Drive-bys**:

- the static `AUTH_TYPE` property of each auth provider is now `public` instead of `private`
- when adding or removing keys from SharedPreferences, changes are applied in bulk rather than one at a time.
