### PR TITLE
STITCH-1139 Android SDK: Create factory for clients

### DIFF
--- a/stitch/src/androidTest/java/com/mongodb/stitch/StitchClientServiceTest.kt
+++ b/stitch/src/androidTest/java/com/mongodb/stitch/StitchClientServiceTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.support.test.InstrumentationRegistry
 import android.support.test.runner.AndroidJUnit4
 import com.mongodb.stitch.android.StitchClient
+import com.mongodb.stitch.android.StitchClientFactory
 import com.mongodb.stitch.android.auth.anonymous.AnonymousAuthProvider
 import com.mongodb.stitch.android.auth.apiKey.APIKey
 import com.mongodb.stitch.android.auth.apiKey.APIKeyProvider
@@ -33,10 +34,10 @@ class StitchClientServiceTest {
     private val instrumentationCtx: Context by lazy { InstrumentationRegistry.getContext() }
     /** [StitchClient] for this test */
     private val stitchClient: StitchClient by lazy {
-        StitchClient(
+        await(StitchClientFactory.create(
                 instrumentationCtx,
                 "test-uybga"
-        )
+        ))
     }
 
     private val email: String = "stitch@mongodb.com"
@@ -228,7 +229,7 @@ class StitchClientServiceTest {
 
     @Test
     fun testMultipleLoginSemantics() {
-        val mlsStitchClient = StitchClient(instrumentationCtx, "stitch-tests-android-sdk-rqopr")
+        val mlsStitchClient = await(StitchClientFactory.create(instrumentationCtx, "stitch-tests-android-sdk-rqopr"))
         clearStitchClient(instrumentationCtx, mlsStitchClient)
 
         // check storage

--- a/stitch/src/main/java/com/mongodb/stitch/android/StitchClient.java
+++ b/stitch/src/main/java/com/mongodb/stitch/android/StitchClient.java
@@ -99,7 +99,7 @@ public class StitchClient {
      * @param clientAppId The App ID for the Stitch app.
      * @param baseUrl     The base URL of the Stitch Client API server.
      */
-    public StitchClient(final Context context, final String clientAppId, final String baseUrl) {
+    StitchClient(final Context context, final String clientAppId, final String baseUrl) {
         _context = context;
         _queue = Volley.newRequestQueue(context);
         _objMapper = CustomObjectMapper.createObjectMapper();
@@ -141,16 +141,8 @@ public class StitchClient {
      * @param context     The Android {@link Context} that this client should be bound to.
      * @param clientAppId The App ID for the Stitch app.
      */
-    public StitchClient(final Context context, final String clientAppId) {
+    StitchClient(final Context context, final String clientAppId) {
         this(context, clientAppId, DEFAULT_BASE_URL);
-    }
-
-    /**
-     * @param context The Android {@link Context} that this client should be bound to.
-     * @return A client derived from the properties file.
-     */
-    public static StitchClient fromProperties(final Context context) {
-        return new StitchClient(context, null, null);
     }
 
     // Public Methods

--- a/stitch/src/main/java/com/mongodb/stitch/android/StitchClientFactory.java
+++ b/stitch/src/main/java/com/mongodb/stitch/android/StitchClientFactory.java
@@ -1,0 +1,39 @@
+package com.mongodb.stitch.android;
+
+import android.content.Context;
+
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.Tasks;
+
+/**
+ *  A StitchClientFactory can be used to asynchronously create instances of StitchClient.
+ */
+public class StitchClientFactory {
+
+    /**
+     * @param context     The Android {@link Context} that this client should be bound to.
+     * @param clientAppId The App ID for the Stitch app.
+     * @param baseUrl     The base URL of the Stitch Client API server.
+     * @return A task containing a StitchClient.
+     */
+    public static Task<StitchClient> create(final Context context, final String clientAppId, String baseUrl) {
+        return Tasks.forResult(new StitchClient(context, clientAppId, baseUrl));
+    }
+
+    /**
+     * @param context     The Android {@link Context} that this client should be bound to.
+     * @param clientAppId The App ID for the Stitch app.
+     * @return A task containing a StitchClient.
+     */
+    public static Task<StitchClient> create(final Context context, final String clientAppId) {
+        return Tasks.forResult(new StitchClient(context, clientAppId));
+    }
+
+    /**
+     * @param context The Android {@link Context} that this client should be bound to.
+     * @return A task containing a StitchClient derived from the properties file.
+     */
+    public static Task<StitchClient> createFromProperties(final Context context) {
+        return Tasks.forResult(new StitchClient(context, null, null));
+    }
+}


### PR DESCRIPTION
This is relatively straightforward, and functionally similar to the change in the iOS SDK. However there's no factory interface since we can't do static interface methods until Java 8, and there's also an additional `createFromProperties()` method on the factory class.