### PR TITLE
fix FQ_NAME for anon provider

### DIFF
--- a/stitch/src/main/java/com/mongodb/stitch/android/auth/anonymous/AnonymousAuthProviderInfo.java
+++ b/stitch/src/main/java/com/mongodb/stitch/android/auth/anonymous/AnonymousAuthProviderInfo.java
@@ -13,7 +13,7 @@ import com.mongodb.stitch.android.auth.AuthProviderInfo;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class AnonymousAuthProviderInfo extends AuthProviderInfo {
-    public static final String FQ_NAME = "anon/user";
+    public static final String FQ_NAME = "anon-user";
 
     @JsonCreator
     public AnonymousAuthProviderInfo(@JsonProperty(Fields.TYPE) @Nullable final String type,


### PR DESCRIPTION
The FQ_NAME for the anon provider was wrong, so `getAuthProviders()` on the `StitchClient` always would return false for `.hasAnonymous()`.