### PR TITLE
STITCH-1317 Handle transport timeouts

### DIFF
--- a/android-core/src/main/java/com/mongodb/stitch/android/core/Stitch.java
+++ b/android-core/src/main/java/com/mongodb/stitch/android/core/Stitch.java
@@ -15,6 +15,7 @@ import java.util.Map;
 
 public final class Stitch {
   private static final String DEFAULT_BASE_URL = "https://stitch.mongodb.com";
+  private static final Long DEFAULT_TRANSPORT_TIMEOUT_MILLIS = 15000L;
   private static final String TAG = Stitch.class.getSimpleName();
   private static final Map<String, StitchAppClientImpl> appClients = new HashMap<>();
   private static boolean initialized;
@@ -99,6 +100,9 @@ public final class Stitch {
     }
     if (configBuilder.getTransport() == null) {
       configBuilder.withTransport(new OkHttpTransport());
+    }
+    if (configBuilder.getTransportTimeout() == null) {
+      configBuilder.withTransportTimeout(DEFAULT_TRANSPORT_TIMEOUT_MILLIS);
     }
     if (configBuilder.getBaseURL() == null || configBuilder.getBaseURL().isEmpty()) {
       configBuilder.withBaseURL(DEFAULT_BASE_URL);

--- a/android-core/src/main/java/com/mongodb/stitch/android/core/internal/StitchAppClientImpl.java
+++ b/android-core/src/main/java/com/mongodb/stitch/android/core/internal/StitchAppClientImpl.java
@@ -38,7 +38,10 @@ public final class StitchAppClientImpl implements StitchAppClient {
             config.getCodecRegistry());
     this.routes = new StitchAppRoutes(this.info.clientAppId);
     final StitchRequestClient requestClient =
-        new StitchRequestClient(config.getBaseURL(), config.getTransport());
+        new StitchRequestClient(
+                config.getBaseURL(),
+                config.getTransport(),
+                config.getTransportTimeout());
     this.auth =
         new StitchAuthImpl(
             requestClient, this.routes.getAuthRoutes(), config.getStorage(), dispatcher, this.info);

--- a/core-admin-client/src/main/java/com/mongodb/stitch/core/admin/StitchAdminClient.kt
+++ b/core-admin-client/src/main/java/com/mongodb/stitch/core/admin/StitchAdminClient.kt
@@ -14,9 +14,14 @@ class StitchAdminClient private constructor(
     companion object {
         const val apiPath = "/api/admin/v3.0"
         private const val defaultServerUrl = "http://localhost:9090"
+        private const val defaultTransportTimeoutMillis = 15000L
 
-        fun create(baseUrl: String = defaultServerUrl): StitchAdminClient {
-            val requestClient = StitchRequestClient(baseUrl, OkHttpTransport())
+        fun create(baseUrl: String = defaultServerUrl,
+                   timeoutMillis: Long = defaultTransportTimeoutMillis): StitchAdminClient {
+            val requestClient = StitchRequestClient(
+                    baseUrl,
+                    OkHttpTransport(),
+                    timeoutMillis)
             val authRoutes = StitchAdminAuthRoutes()
 
             val adminAuth = StitchAdminAuth(

--- a/core/src/main/java/com/mongodb/stitch/core/StitchClientConfiguration.java
+++ b/core/src/main/java/com/mongodb/stitch/core/StitchClientConfiguration.java
@@ -12,6 +12,7 @@ public class StitchClientConfiguration {
   private final Storage storage;
   private final String dataDirectory;
   private final Transport transport;
+  private final Long transportTimeout;
   private final CodecRegistry codecRegistry;
 
   StitchClientConfiguration(final StitchClientConfiguration config) {
@@ -19,6 +20,7 @@ public class StitchClientConfiguration {
     this.storage = config.storage;
     this.dataDirectory = config.dataDirectory;
     this.transport = config.transport;
+    this.transportTimeout = config.transportTimeout;
     this.codecRegistry = config.codecRegistry;
   }
 
@@ -27,11 +29,13 @@ public class StitchClientConfiguration {
       final Storage storage,
       final String dataDirectory,
       final Transport transport,
+      final Long transportTimeout,
       final CodecRegistry codecRegistry) {
     this.baseURL = baseURL;
     this.storage = storage;
     this.dataDirectory = dataDirectory;
     this.transport = transport;
+    this.transportTimeout = transportTimeout;
     this.codecRegistry = codecRegistry;
   }
 
@@ -55,6 +59,19 @@ public class StitchClientConfiguration {
     return transport;
   }
 
+  /**
+   * The number of milliseconds that a {@link Transport} should spend on an HTTP round trip before
+   * failing with an error.
+   *
+   * - important: If the underlying transport internally handles timeouts, it is possible that the
+   *              transport will throw a timeout error before this specified interval. If you
+   *              experience premature timeouts, configure your underlying transport to have a
+   *              longer timeout interval.
+   */
+  public Long getTransportTimeout() {
+    return transportTimeout;
+  }
+
   public CodecRegistry getCodecRegistry() { return codecRegistry; }
 
   public static class Builder {
@@ -62,6 +79,7 @@ public class StitchClientConfiguration {
     private Storage storage;
     private String dataDirectory;
     private Transport transport;
+    private Long transportTimeout;
     private CodecRegistry codecRegistry;
 
     public Builder() {}
@@ -71,6 +89,7 @@ public class StitchClientConfiguration {
       storage = config.storage;
       dataDirectory = config.dataDirectory;
       transport = config.transport;
+      transportTimeout = config.transportTimeout;
       codecRegistry = config.codecRegistry;
     }
 
@@ -95,6 +114,21 @@ public class StitchClientConfiguration {
     @SuppressWarnings("UnusedReturnValue")
     public Builder withTransport(final Transport transport) {
       this.transport = transport;
+      return this;
+    }
+
+    /**
+     * Sets the number of milliseconds that a {@link Transport} should spend on an HTTP round trip
+     * before failing with an error.
+     *
+     * - important: If the underlying transport internally handles timeouts, it is possible that
+     *              the transport will throw a timeout error before this specified interval. If you
+     *              experience premature timeouts, configure your underlying transport to have a
+     *              longer timeout interval.
+     */
+    @SuppressWarnings("UnusedReturnValue")
+    public Builder withTransportTimeout(final Long transportTimeout) {
+      this.transportTimeout = transportTimeout;
       return this;
     }
 
@@ -127,6 +161,10 @@ public class StitchClientConfiguration {
       return transport;
     }
 
+    public Long getTransportTimeout() {
+      return transportTimeout;
+    }
+
     public CodecRegistry getCodecRegistry() { return codecRegistry; }
 
     public StitchClientConfiguration build() {
@@ -142,7 +180,17 @@ public class StitchClientConfiguration {
         throw new IllegalArgumentException("transport must be set");
       }
 
-      return new StitchClientConfiguration(baseURL, storage, dataDirectory, transport, codecRegistry);
+      if (transportTimeout == null) {
+        throw new IllegalArgumentException("transport timeout must be set");
+      }
+
+      return new StitchClientConfiguration(
+              baseURL,
+              storage,
+              dataDirectory,
+              transport,
+              transportTimeout,
+              codecRegistry);
     }
   }
 }

--- a/core/src/main/java/com/mongodb/stitch/core/StitchRequestErrorCode.java
+++ b/core/src/main/java/com/mongodb/stitch/core/StitchRequestErrorCode.java
@@ -5,5 +5,6 @@ package com.mongodb.stitch.core;
  */
 public enum StitchRequestErrorCode {
     TRANSPORT_ERROR,
+    TRANSPORT_TIMEOUT_ERROR,
     DECODING_ERROR
 }

--- a/core/src/main/java/com/mongodb/stitch/core/internal/net/StitchRequestClient.java
+++ b/core/src/main/java/com/mongodb/stitch/core/internal/net/StitchRequestClient.java
@@ -6,15 +6,26 @@ import com.mongodb.stitch.core.StitchRequestException;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public class StitchRequestClient {
 
   private final String baseURL;
   private final Transport transport;
+  private final Long transportTimeout;
 
-  public StitchRequestClient(final String baseURL, final Transport transport) {
+  public StitchRequestClient(final String baseURL,
+                             final Transport transport,
+                             final Long transportTimeout) {
     this.baseURL = baseURL;
     this.transport = transport;
+    this.transportTimeout = transportTimeout;
   }
 
   private static Response inspectResponse(final Response response) {
@@ -27,11 +38,39 @@ public class StitchRequestClient {
   }
 
   public Response doRequest(final StitchRequest stitchReq) {
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    Future<Response> future = executor.submit(new Callable<Response>() {
+      @Override
+      public Response call() {
+        final Response response;
+        try {
+          response = transport.roundTrip(buildRequest(stitchReq));
+        } catch (Exception e) {
+          throw new StitchRequestException(e, StitchRequestErrorCode.TRANSPORT_ERROR);
+        }
+
+        return response;
+      }
+    });
+
     final Response response;
     try {
-      response = transport.roundTrip(buildRequest(stitchReq));
-    } catch (Exception e) {
+      response = future.get(transportTimeout, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      // Handle an interrupted thread, though this this is unlikely.
       throw new StitchRequestException(e, StitchRequestErrorCode.TRANSPORT_ERROR);
+    } catch (ExecutionException e) {
+      // Handle an underlying transport error.
+      if (e.getCause() instanceof StitchRequestException) {
+        throw (StitchRequestException) e.getCause();
+      }
+      throw new StitchRequestException(e, StitchRequestErrorCode.TRANSPORT_ERROR);
+    } catch (TimeoutException e) {
+      // Handle timeouts.
+      future.cancel(true);
+      throw new StitchRequestException(null, StitchRequestErrorCode.TRANSPORT_TIMEOUT_ERROR);
+    } finally {
+      executor.shutdown();
     }
 
     return inspectResponse(response);

--- a/core/src/test/java/com/mongodb/stitch/core/StitchAppClientConfigurationUnitTests.java
+++ b/core/src/test/java/com/mongodb/stitch/core/StitchAppClientConfigurationUnitTests.java
@@ -24,6 +24,7 @@ class StitchAppClientConfigurationUnitTests {
     private static final Storage STORAGE = new MemoryStorage();
     private static final Transport TRANSPORT = (Request request) ->
         new Response(200, null, null);
+    private static final Long TRANSPORT_TIMEOUT = 15000L;
 
     @Test
     void testStitchAppClientConfigurationBuilderInit() {
@@ -48,6 +49,10 @@ class StitchAppClientConfigurationUnitTests {
 
         builder.withTransport(TRANSPORT);
 
+        assertThrows(IllegalArgumentException.class, builder::build);
+
+        builder.withTransportTimeout(TRANSPORT_TIMEOUT);
+
         final StitchAppClientConfiguration config = builder.build();
 
         assertEquals(config.getClientAppId(), CLIENT_APP_ID);
@@ -56,6 +61,7 @@ class StitchAppClientConfigurationUnitTests {
         assertEquals(config.getBaseURL(), BASE_URL);
         assertEquals(config.getStorage(), STORAGE);
         assertEquals(config.getTransport(), TRANSPORT);
+        assertEquals(config.getTransportTimeout(), TRANSPORT_TIMEOUT);
         assertEquals(config.getCodecRegistry(), null);
     }
 
@@ -82,6 +88,10 @@ class StitchAppClientConfigurationUnitTests {
 
         builder.withTransport(TRANSPORT);
 
+        assertThrows(IllegalArgumentException.class, builder::build);
+
+        builder.withTransportTimeout(TRANSPORT_TIMEOUT);
+
         Codec<CustomType> customTypeCodec = new CustomType.Codec();
         builder.withCustomCodecs(CodecRegistries.fromCodecs(customTypeCodec));
 
@@ -93,6 +103,7 @@ class StitchAppClientConfigurationUnitTests {
         assertEquals(config.getBaseURL(), BASE_URL);
         assertEquals(config.getStorage(), STORAGE);
         assertEquals(config.getTransport(), TRANSPORT);
+        assertEquals(config.getTransportTimeout(), TRANSPORT_TIMEOUT);
 
         // Ensure that there is a codec for our custom type.
         assertEquals(config.getCodecRegistry().get(CustomType.class), customTypeCodec);

--- a/core/src/test/java/com/mongodb/stitch/core/StitchClientConfigurationUnitTests.java
+++ b/core/src/test/java/com/mongodb/stitch/core/StitchClientConfigurationUnitTests.java
@@ -28,6 +28,7 @@ class StitchClientConfigurationUnitTests {
     private final Storage storage = new MemoryStorage();
     private final Transport transport = (Request request) ->
             new Response(200, null, null);
+    private final Long transportTimeout = 15000L;
 
     @Test
     void testStitchClientConfigurationBuilderImplInit() {
@@ -46,11 +47,16 @@ class StitchClientConfigurationUnitTests {
 
         builder.withTransport(this.transport);
 
+        assertThrows(IllegalArgumentException.class, builder::build);
+
+        builder.withTransportTimeout(this.transportTimeout);
+
         final StitchClientConfiguration config = builder.build();
 
         assertEquals(config.getBaseURL(), this.baseURL);
         assertEquals(config.getStorage(), this.storage);
         assertEquals(config.getTransport(), this.transport);
+        assertEquals(config.getTransportTimeout(), this.transportTimeout);
         assertEquals(config.getCodecRegistry(), null);
     }
 
@@ -71,6 +77,10 @@ class StitchClientConfigurationUnitTests {
 
         builder.withTransport(this.transport);
 
+        assertThrows(IllegalArgumentException.class, builder::build);
+
+        builder.withTransportTimeout(this.transportTimeout);
+
         CustomType.Codec customTypeCodec = new CustomType.Codec();
 
         builder.withCustomCodecs(CodecRegistries.fromCodecs(
@@ -82,6 +92,7 @@ class StitchClientConfigurationUnitTests {
         assertEquals(config.getBaseURL(), this.baseURL);
         assertEquals(config.getStorage(), this.storage);
         assertEquals(config.getTransport(), this.transport);
+        assertEquals(config.getTransportTimeout(), this.transportTimeout);
 
         // Ensure that there is a codec for our custom type.
         assertEquals(config.getCodecRegistry().get(CustomType.class), customTypeCodec);

--- a/core/src/test/java/com/mongodb/stitch/core/auth/internal/AccessTokenRefreshUnitTests.java
+++ b/core/src/test/java/com/mongodb/stitch/core/auth/internal/AccessTokenRefreshUnitTests.java
@@ -14,6 +14,7 @@ import com.mongodb.stitch.core.internal.net.StitchDocRequest;
 import com.mongodb.stitch.core.internal.net.StitchRequest;
 import com.mongodb.stitch.core.internal.net.StitchRequestClient;
 import com.mongodb.stitch.core.mock.MockCoreAnonymousAuthProviderClient;
+import com.mongodb.stitch.core.testutil.Constants;
 
 import org.bson.Document;
 import org.bson.types.ObjectId;
@@ -188,7 +189,9 @@ class AccessTokenRefreshUnitTests {
         };
 
         MockRequestClient() {
-            super("http://localhost:8080", null);
+            super("http://localhost:8080",
+                    null,
+                    Constants.DEFAULT_TRANSPORT_TIMEOUT_MILLISECONDS);
         }
 
         void setHandleAuthProviderLoginRoute(Function<StitchRequest, Response> handleAuthProviderLoginRoute) {

--- a/core/src/test/java/com/mongodb/stitch/core/auth/internal/CoreStitchAuthUnitTests.java
+++ b/core/src/test/java/com/mongodb/stitch/core/auth/internal/CoreStitchAuthUnitTests.java
@@ -22,6 +22,7 @@ import com.mongodb.stitch.core.internal.common.StitchObjectMapper;
 import com.mongodb.stitch.core.internal.net.Response;
 import com.mongodb.stitch.core.mock.MockCoreStitchAuthForCodecTests;
 import com.mongodb.stitch.core.mock.MockRequestClientForCodecTests;
+import com.mongodb.stitch.core.testutil.Constants;
 import com.mongodb.stitch.core.testutil.CustomType;
 
 import org.bson.Document;
@@ -197,7 +198,9 @@ class CoreStitchAuthUnitTests {
         };
 
         MockRequestClient() {
-            super("http://localhost:8080", null);
+            super("http://localhost:8080",
+                    null,
+                    Constants.DEFAULT_TRANSPORT_TIMEOUT_MILLISECONDS);
         }
 
         Function<StitchRequest, Response> getHandleAuthProviderLinkRoute() {

--- a/core/src/test/java/com/mongodb/stitch/core/auth/providers/userpass/CoreUserPasswordAuthProviderClientUnitTests.java
+++ b/core/src/test/java/com/mongodb/stitch/core/auth/providers/userpass/CoreUserPasswordAuthProviderClientUnitTests.java
@@ -7,6 +7,7 @@ import com.mongodb.stitch.core.internal.net.Request;
 import com.mongodb.stitch.core.internal.net.Response;
 import com.mongodb.stitch.core.internal.net.StitchAppRoutes;
 import com.mongodb.stitch.core.internal.net.StitchRequestClient;
+import com.mongodb.stitch.core.testutil.Constants;
 
 import org.bson.Document;
 import org.junit.jupiter.api.Test;
@@ -64,7 +65,8 @@ class CoreUserPasswordAuthProviderClientUnitTests {
                     e.printStackTrace();
                     return null;
                 }
-            }),
+            },
+            Constants.DEFAULT_TRANSPORT_TIMEOUT_MILLISECONDS),
             this.routes.getAuthRoutes()
     ) { };
 

--- a/core/src/test/java/com/mongodb/stitch/core/mock/MockRequestClientForCodecTests.java
+++ b/core/src/test/java/com/mongodb/stitch/core/mock/MockRequestClientForCodecTests.java
@@ -7,6 +7,7 @@ import com.mongodb.stitch.core.internal.net.StitchAppRoutes;
 import com.mongodb.stitch.core.internal.net.StitchDocRequest;
 import com.mongodb.stitch.core.internal.net.StitchRequest;
 import com.mongodb.stitch.core.internal.net.StitchRequestClient;
+import com.mongodb.stitch.core.testutil.Constants;
 
 import org.bson.types.ObjectId;
 
@@ -51,7 +52,9 @@ public final class MockRequestClientForCodecTests extends StitchRequestClient {
     public static final String LIST_VALUE_TEST_ROUTE = "http://localhost:8080/list_value";
 
     public MockRequestClientForCodecTests() {
-        super("http://localhost:8080", null);
+        super("http://localhost:8080",
+                null,
+                Constants.DEFAULT_TRANSPORT_TIMEOUT_MILLISECONDS);
     }
 
     private Response handleRequest(StitchRequest request) {

--- a/core/src/test/java/com/mongodb/stitch/core/testutil/Constants.java
+++ b/core/src/test/java/com/mongodb/stitch/core/testutil/Constants.java
@@ -1,0 +1,5 @@
+package com.mongodb.stitch.core.testutil;
+
+public final class Constants {
+public static final Long DEFAULT_TRANSPORT_TIMEOUT_MILLISECONDS = 15000L;
+}


### PR DESCRIPTION
This was basically the same change as for Swift. I added a transport timeout setting to client configuration, and I modified doRequest in the StitchRequestClient to perform the Transport round trip on a background thread, and wrote a test. 

I'm somewhat concerned with the performance implications of the ExecutorService I'm using to wait for the round trip to finish, so I would like some feedback on that, mainly since I'm not too familiar with concurrency in Java.