### PR TITLE
STITCH-1970 Optimize UPDATE and REPLACE to be $set and $unset

### DIFF
--- a/android/services/mongodb-remote/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/remote/RemoteMongoClientIntTests.kt
+++ b/android/services/mongodb-remote/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/remote/RemoteMongoClientIntTests.kt
@@ -63,12 +63,15 @@ class RemoteMongoClientIntTests : BaseStitchAndroidIntTest() {
                 "mongodb1",
                 ServiceConfigs.Mongo(getMongoDbUri()))
 
-        val rule = Document()
-        rule["read"] = Document()
-        rule["write"] = Document()
-        rule["other_fields"] = Document()
+        val rule = RuleCreator.MongoDb(
+            database = dbName,
+            collection = collName,
+            roles = listOf(RuleCreator.MongoDb.Role(
+                read = true, write = true
+            )),
+            schema = RuleCreator.MongoDb.Schema())
 
-        addRule(svc.second, RuleCreator.MongoDb("$dbName.$collName", rule))
+        addRule(svc.second, rule)
 
         val client = getAppClient(app.first)
         Tasks.await(client.auth.loginWithCredential(AnonymousCredential()))

--- a/android/services/mongodb-remote/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/remote/internal/SyncMongoClientIntTests.kt
+++ b/android/services/mongodb-remote/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/remote/internal/SyncMongoClientIntTests.kt
@@ -152,7 +152,7 @@ class SyncMongoClientIntTests : BaseStitchAndroidIntTest(), SyncIntTestRunner {
         addRule(svc2.second, rule)
 
         val client = getAppClient(app.first)
-        client.auth.loginWithCredential(AnonymousCredential())
+        Tasks.await(client.auth.loginWithCredential(AnonymousCredential()))
         mongoClient = client.getServiceClient(RemoteMongoClient.factory, "mongodb1")
         (mongoClient as RemoteMongoClientImpl).dataSynchronizer.stop()
         (mongoClient as RemoteMongoClientImpl).dataSynchronizer.disableSyncThread()

--- a/core/admin-client/src/main/java/com/mongodb/stitch/core/admin/Resources.kt
+++ b/core/admin-client/src/main/java/com/mongodb/stitch/core/admin/Resources.kt
@@ -92,8 +92,9 @@ inline fun <Creator, reified T> Creatable<Creator, T>.create(data: Creator): T {
             .withBody(writer.writeValueAsString(data).toByteArray())
 
     val response = adminAuth.doAuthenticatedRequest(reqBuilder.build())
+    val str = response.body?.bufferedReader().use { it?.readText() }
     return objMapper.readValue(
-            response.body,
+            str,
             T::class.java
     )
 }
@@ -201,7 +202,7 @@ class Apps(adminAuth: StitchAdminAuth, url: String) :
                     // / Resource for a specific rule of a service
                     class Rule(adminAuth: StitchAdminAuth, url: String) :
                             BasicResource(adminAuth, url),
-                            Gettable<RuleResponse>, Removable
+                            Gettable<RuleResponse>, Removable, Updatable<RuleCreator>
                 }
 
                 val rules by lazy { Rules(this.adminAuth, "$url/rules") }

--- a/core/admin-client/src/main/java/com/mongodb/stitch/core/admin/Resources.kt
+++ b/core/admin-client/src/main/java/com/mongodb/stitch/core/admin/Resources.kt
@@ -92,9 +92,8 @@ inline fun <Creator, reified T> Creatable<Creator, T>.create(data: Creator): T {
             .withBody(writer.writeValueAsString(data).toByteArray())
 
     val response = adminAuth.doAuthenticatedRequest(reqBuilder.build())
-    val str = response.body?.bufferedReader().use { it?.readText() }
     return objMapper.readValue(
-            str,
+            response.body,
             T::class.java
     )
 }

--- a/core/admin-client/src/main/java/com/mongodb/stitch/core/admin/services/rules/RulesResources.kt
+++ b/core/admin-client/src/main/java/com/mongodb/stitch/core/admin/services/rules/RulesResources.kt
@@ -3,8 +3,6 @@ package com.mongodb.stitch.core.admin.services.rules
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.mongodb.stitch.core.admin.Apps
-import org.bson.BsonBoolean
-import org.bson.BsonValue
 import org.bson.Document
 
 enum class AwsS3Actions {
@@ -40,31 +38,38 @@ sealed class RuleCreator {
     data class Fcm(val name: String, val actions: Set<FcmActions>) : RuleCreator()
     data class Http(val name: String, val actions: Set<HttpActions>) : RuleCreator()
 
-    data class MongoDb(val database: String,
-                       val collection: String,
-                       val roles: List<Role>,
-                       val schema: Schema) : RuleCreator() {
-        data class Role(val name: String = "default",
-                        @JsonProperty("apply_when")
-                        val applyWhen: Document = Document(),
-                        val fields: Document = Document(),
-                        @JsonProperty("additional_fields")
-                        val additionalFields: AdditionalFields = AdditionalFields(),
-                        val read: Boolean = true,
-                        val write: Boolean? = null,
-                        val insert: Boolean = true,
-                        val delete: Boolean = true) {
-            data class AdditionalFields(val write: Boolean = true,
-                                        val read: Boolean = true)
+    data class MongoDb(
+        val database: String,
+        val collection: String,
+        val roles: List<Role>,
+        val schema: Schema
+    ) : RuleCreator() {
+        data class Role(
+            val name: String = "default",
+            @JsonProperty("apply_when")
+            val applyWhen: Document = Document(),
+            val fields: Document = Document(),
+            @JsonProperty("additional_fields")
+            val additionalFields: AdditionalFields = AdditionalFields(),
+            val read: Boolean = true,
+            val write: Boolean? = null,
+            val insert: Boolean = true,
+            val delete: Boolean = true
+        ) {
+            data class AdditionalFields(
+                val write: Boolean = true,
+                val read: Boolean = true
+            )
         }
-        data class Schema(val properties: Document = Document("_id", Document("bsonType", "objectId")))
+        data class Schema(
+            val properties: Document = Document("_id", Document("bsonType", "objectId"))
+        )
     }
     data class Twilio(val name: String, val actions: Set<TwilioActions>) : RuleCreator()
 }
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 class RuleResponse(@JsonProperty("_id") val _id: String)
-
 
 // / GET a rule
 // / - parameter id: id of the requested rule

--- a/core/admin-client/src/main/java/com/mongodb/stitch/core/admin/services/rules/RulesResources.kt
+++ b/core/admin-client/src/main/java/com/mongodb/stitch/core/admin/services/rules/RulesResources.kt
@@ -1,8 +1,10 @@
 package com.mongodb.stitch.core.admin.services.rules
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.mongodb.stitch.core.admin.Apps
+import org.bson.BsonBoolean
+import org.bson.BsonValue
 import org.bson.Document
 
 enum class AwsS3Actions {
@@ -37,15 +39,35 @@ sealed class RuleCreator {
     data class AwsSes(val name: String, val actions: Set<AwsSesActions>) : RuleCreator()
     data class Fcm(val name: String, val actions: Set<FcmActions>) : RuleCreator()
     data class Http(val name: String, val actions: Set<HttpActions>) : RuleCreator()
-    data class MongoDb(val namespace: String, private val rule: Document) : RuleCreator() {
-        @JsonAnyGetter
-        fun toRule(): Map<String, Any> {
-            rule["namespace"] = namespace
-            return rule
+
+    data class MongoDb(val database: String,
+                       val collection: String,
+                       val roles: List<Role>,
+                       val schema: Schema) : RuleCreator() {
+        data class Role(val name: String = "default",
+                        @JsonProperty("apply_when")
+                        val applyWhen: Document = Document(),
+                        val fields: Document = Document(),
+                        @JsonProperty("additional_fields")
+                        val additionalFields: AdditionalFields = AdditionalFields(),
+                        val read: Boolean = true,
+                        val write: Boolean? = null,
+                        val insert: Boolean = true,
+                        val delete: Boolean = true) {
+            data class AdditionalFields(val write: Boolean = true,
+                                        val read: Boolean = true)
         }
+        data class Schema(val properties: Document = Document("_id", Document("bsonType", "objectId")))
     }
     data class Twilio(val name: String, val actions: Set<TwilioActions>) : RuleCreator()
 }
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-class RuleResponse
+class RuleResponse(@JsonProperty("_id") val _id: String)
+
+
+// / GET a rule
+// / - parameter id: id of the requested rule
+fun Apps.App.Services.Service.Rules.rule(id: String): Apps.App.Services.Service.Rules.Rule {
+    return Apps.App.Services.Service.Rules.Rule(this.adminAuth, "$url/$id")
+}

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/ChangeEvent.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/ChangeEvent.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
+import org.bson.BsonElement;
 import org.bson.BsonReader;
 import org.bson.BsonString;
 import org.bson.BsonType;
@@ -40,6 +41,8 @@ import org.bson.codecs.Codec;
 import org.bson.codecs.Decoder;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
+
+import javax.annotation.Nullable;
 
 // TODO: Should there be a local and remote type for the pending part?
 public final class ChangeEvent<DocumentT> {
@@ -150,6 +153,116 @@ public final class ChangeEvent<DocumentT> {
 
     public Collection<String> getRemovedFields() {
       return removedFields;
+    }
+
+    /**
+     * Convert this update description to an update document.
+     * @return an update document with the appropriate $set and $unset
+     *         documents
+     */
+    BsonDocument toUpdateDocument() {
+      final List<BsonElement> unsets = new ArrayList<>();
+      for (final String removedField : this.removedFields) {
+        unsets.add(new BsonElement(removedField, new BsonBoolean(true)));
+      }
+      return new BsonDocument("$set", this.updatedFields)
+          .append("$unset", new BsonDocument(unsets));
+    }
+
+    static UpdateDescription fromUpdateDocument(final BsonDocument updateDocument) {
+      final BsonDocument updatedFields = updateDocument.getDocument("$set");
+      final BsonDocument removedFields = updateDocument.getDocument("$unset");
+      final List<String> removedFieldsKeys = new ArrayList<>();
+
+      for (final Map.Entry<String, BsonValue> stringBsonValueEntry : removedFields.entrySet()) {
+        removedFieldsKeys.add(stringBsonValueEntry.getKey());
+      }
+
+      return new UpdateDescription(updatedFields, removedFieldsKeys);
+    }
+
+    /**
+     * Find the diff between two documents.
+     *
+     * NOTE: This does not do a full diff on [BsonArray]. If there is
+     * an inequality between the old and new array, the old array will
+     * simply be replaced by the new one.
+     *
+     * @param thisDocument original document
+     * @param thatDocument document to diff on
+     * @param onKey the key for our depth level
+     * @param updatedFields contiguous document of updated fields,
+     *                      nested or otherwise
+     * @param removedFields contiguous list of removedFields,
+     *                      nested or otherwise
+     * @return a description of the updated fields and removed keys between
+     *         the documents
+     */
+    private static UpdateDescription diff(final BsonDocument thisDocument,
+                                          final BsonDocument thatDocument,
+                                          final @Nullable String onKey,
+                                          final BsonDocument updatedFields,
+                                          final List<String> removedFields) {
+      // for each key in this document...
+      for (Map.Entry<String, BsonValue> entry: thisDocument.entrySet()) {
+        final String key = entry.getKey();
+        final BsonValue oldValue = entry.getValue();
+
+        final String actualKey = onKey == null ? key : String.format("%s.%s", onKey, key);
+        // if the key exists in the other document AND both are BsonDocuments
+        // diff the documents recursively, carrying over the keys to keep
+        // updatedFields and removedFields flat.
+        // this will allow us to reference whole objects as well as nested
+        // properties.
+        // else if the key does not exist, the key has been removed.
+        if (thatDocument.containsKey(key)) {
+          final BsonValue newValue = thatDocument.get(key);
+          if (oldValue instanceof BsonDocument && newValue instanceof BsonDocument) {
+            diff((BsonDocument) oldValue,
+                (BsonDocument) newValue,
+                actualKey,
+                updatedFields,
+                removedFields);
+          } else if (!oldValue.equals(newValue)) {
+            updatedFields.put(actualKey, newValue);
+          }
+        } else {
+          removedFields.add(actualKey);
+        }
+      }
+
+      // for each key in the other document...
+      for (Map.Entry<String, BsonValue> entry: thatDocument.entrySet()) {
+        final String key = entry.getKey();
+        final BsonValue newValue= entry.getValue();
+        // if the key is not in the this document,
+        // it is a new key with a new value.
+        // updatedFields will included keys that must
+        // be newly created.
+        final String actualKey = onKey == null ? key : String.format("%s.%s", onKey, key);;
+        if (!thisDocument.containsKey(key)) {
+          updatedFields.put(actualKey, newValue);
+        }
+      }
+
+      return new UpdateDescription(updatedFields, removedFields);
+    }
+
+    /**
+     * Find the diff between two documents.
+     *
+     * NOTE: This does not do a full diff on [BsonArray]. If there is
+     * an inequality between the old and new array, the old array will
+     * simply be replaced by the new one.
+     *
+     * @param thisDocument original document
+     * @param thatDocument document to diff on
+     * @return a description of the updated fields and removed keys between
+     *         the documents
+     */
+    static UpdateDescription diff(BsonDocument thisDocument,
+                                  BsonDocument thatDocument) {
+      return UpdateDescription.diff(thisDocument, thatDocument, null, new BsonDocument(), new ArrayList<>());
     }
   }
 
@@ -343,14 +456,7 @@ public final class ChangeEvent<DocumentT> {
   static ChangeEvent<BsonDocument> changeEventForLocalUpdate(
       final MongoNamespace namespace,
       final BsonValue documentId,
-
-      // Unused for now since embedded does not offer change streams
-      // nor a way to get an UpdateDescription. This results in updates
-      // being processed as full document replacements (FDRs). Some
-      // workarounds are diffing the previous and new document or parsing
-      // the update modifiers against the old document. FDRs are bad
-      // because they require more permissive Stitch rules.
-      final BsonDocument update,
+      final UpdateDescription update,
       final BsonDocument document,
       final boolean writePending
   ) {
@@ -360,7 +466,7 @@ public final class ChangeEvent<DocumentT> {
         document,
         namespace,
         new BsonDocument("_id", documentId),
-        null,
+        update,
         writePending);
   }
 

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/ChangeEvent.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/ChangeEvent.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
@@ -42,8 +43,6 @@ import org.bson.codecs.Codec;
 import org.bson.codecs.Decoder;
 import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
-
-import javax.annotation.Nullable;
 
 // TODO: Should there be a local and remote type for the pending part?
 public final class ChangeEvent<DocumentT> {
@@ -193,8 +192,9 @@ public final class ChangeEvent<DocumentT> {
                                           final BsonDocument updatedFields,
                                           final List<String> removedFields) {
       // for each key in this document...
-      for (Map.Entry<String, BsonValue> entry: thisDocument.entrySet()) {
+      for (final Map.Entry<String, BsonValue> entry: thisDocument.entrySet()) {
         final String key = entry.getKey();
+        // don't worry about the _id or version field for now
         if (key.equals("_id") || key.equals(DOCUMENT_VERSION_FIELD)) {
           continue;
         }
@@ -224,13 +224,14 @@ public final class ChangeEvent<DocumentT> {
       }
 
       // for each key in the other document...
-      for (Map.Entry<String, BsonValue> entry: thatDocument.entrySet()) {
+      for (final Map.Entry<String, BsonValue> entry: thatDocument.entrySet()) {
         final String key = entry.getKey();
+        // don't worry about the _id or version field for now
         if (key.equals("_id") || key.equals(DOCUMENT_VERSION_FIELD)) {
           continue;
         }
 
-        final BsonValue newValue= entry.getValue();
+        final BsonValue newValue = entry.getValue();
         // if the key is not in the this document,
         // it is a new key with a new value.
         // updatedFields will included keys that must
@@ -256,9 +257,15 @@ public final class ChangeEvent<DocumentT> {
      * @return a description of the updated fields and removed keys between
      *         the documents
      */
-    static UpdateDescription diff(BsonDocument thisDocument,
-                                  BsonDocument thatDocument) {
-      return UpdateDescription.diff(thisDocument, thatDocument, null, new BsonDocument(), new ArrayList<>());
+    static UpdateDescription diff(final BsonDocument thisDocument,
+                                  final BsonDocument thatDocument) {
+      return UpdateDescription.diff(
+          thisDocument,
+          thatDocument,
+          null,
+          new BsonDocument(),
+          new ArrayList<>()
+      );
     }
   }
 

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/ChangeEvent.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/ChangeEvent.java
@@ -172,7 +172,7 @@ public final class ChangeEvent<DocumentT> {
       }
 
       if (unsets.size() > 0) {
-          updateDocument.append("$unset", new BsonDocument(unsets));
+        updateDocument.append("$unset", new BsonDocument(unsets));
       }
 
       return updateDocument;

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
@@ -1313,7 +1313,7 @@ public class DataSynchronizer implements NetworkMonitor.StateListener {
       if (acceptRemote) {
         // i. If the remote document is equal to the resolved document, replace the document
         //    locally, mark the document as having no pending writes, and emit a REPLACE change
-        //    event.
+        //    event if the document had not existed prior, or UPDATE if it had.
         replaceOrUpsertOneFromRemote(
             namespace,
             docConfig.getDocumentId(),

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
@@ -1662,7 +1662,7 @@ public class DataSynchronizer implements NetworkMonitor.StateListener {
       return;
     }
 
-    BsonDocument beforeResult = getLocalCollection(namespace)
+    final BsonDocument beforeResult = getLocalCollection(namespace)
         .findOneAndReplace(
             getDocumentIdFilter(documentId),
             document,

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/ChangeEventUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/ChangeEventUnitTests.kt
@@ -212,8 +212,10 @@ class ChangeEventUnitTests {
             return newDocument
         }
 
-        fun testUpdatedDocumentMatchesExpectation(originalDocument: BsonDocument,
-                                                  expectedDocumentAfterUpdate: BsonDocument) {
+        fun testUpdatedDocumentMatchesExpectation(
+            originalDocument: BsonDocument,
+            expectedDocumentAfterUpdate: BsonDocument
+        ) {
             // create an update description via diff'ing the two documents.
             val updateDescription = diff(withoutId(originalDocument), withoutId(expectedDocumentAfterUpdate))
 

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/ChangeEventUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/ChangeEventUnitTests.kt
@@ -254,6 +254,8 @@ class ChangeEventUnitTests {
         expectedDocumentAfterUpdate["_id"] = originalDocument["_id"]
         testUpdatedDocumentMatchesExpectation(originalDocument, expectedDocumentAfterUpdate)
         testUpdatedDocumentMatchesExpectation(expectedDocumentAfterUpdate, BsonDocument.parse(expectedJson2))
+
+        harness.close()
     }
 
     @Test

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/ChangeEventUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/ChangeEventUnitTests.kt
@@ -12,7 +12,10 @@ import org.bson.BsonObjectId
 import org.bson.BsonString
 import org.bson.types.ObjectId
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.fail
 import org.junit.Test
+import java.lang.IllegalArgumentException
 
 class ChangeEventUnitTests {
     private val namespace = MongoNamespace("foo", "bar")
@@ -128,120 +131,49 @@ class ChangeEventUnitTests {
 
     @Test
     fun testUpdateDescriptionDiff() {
-        val originalJson = """
-         {
-           "shop_name": "nkd pizza",
-           "address": {
-             "street": "9 orwell rd",
-             "city": "dublin 6",
-             "county": "dublin"
-           },
-           "rating": 5,
-           "menu": [
-             "cheese",
-             "pepperoni",
-             "veggie"
-           ],
-           "employees": [
-             {
-               "name": "aoife",
-               "age": 26,
-               "euro_per_hr": 18,
-               "title": "junior employee"
-             },
-             {
-               "name": "niamh",
-               "age": 27,
-               "euro_per_hr": 20,
-               "title": "chef"
-             },
-           ]
-         }
-        """.trimIndent()
-
-        val expectedJson = """
-         {
-           "shop_name": "nkd pizza",
-           "address": {
-             "street": "10 orwell rd",
-             "city": "dublin 6",
-             "county": "dublin"
-           },
-           "menu": [
-             "cheese",
-             "veggie"
-           ],
-           "employees": [
-             {
-               "name": "aoife",
-               "age": 26,
-               "euro_per_hr": 18,
-               "title": "senior employee"
-             },
-             {
-               "name": "niamh",
-               "age": 27,
-               "euro_per_hr": 20,
-               "title": "chef"
-             },
-             {
-               "name": "alice",
-               "age": 29,
-               "euro_per_hr": 14,
-               "title": "cashier"
-             },
-           ]
-         }
-        """.trimIndent()
-
-                val expectedJson2 = """
-         {
-           "hello": "world"
-         }
-        """.trimIndent()
-
         val harness = SyncUnitTestHarness()
         val client = harness.freshTestContext().localClient
         val collection: MongoCollection<BsonDocument> = client
             .getDatabase("dublin")
             .getCollection("restaurants${ObjectId().toHexString()}", BsonDocument::class.java)
 
-        fun withoutId(document: BsonDocument): BsonDocument {
-            val newDocument = BsonDocument(document.map { BsonElement(it.key, it.value) })
-            newDocument.remove("_id")
-            return newDocument
-        }
-
-        fun testUpdatedDocumentMatchesExpectation(
-            originalDocument: BsonDocument,
-            expectedDocumentAfterUpdate: BsonDocument
-        ) {
-            // create an update description via diff'ing the two documents.
-            val updateDescription = diff(withoutId(originalDocument), withoutId(expectedDocumentAfterUpdate))
-
-            // create an update document from the update description.
-            // update the original document with the update document
-            collection.updateOne(BsonDocument("_id", originalDocument.getObjectId("_id")), updateDescription.toUpdateDocument())
-
-            // assert that our newly updated document reflects our expectations
-            assertEquals(
-                withoutId(expectedDocumentAfterUpdate),
-                collection.aggregate(
-                    listOf(
-                        BsonDocument(
-                            "\$project",
-                            BsonDocument("_id", BsonInt32(0))
-                                .append("employees", BsonDocument("_id", BsonInt32(0)))
-                        ))).first())
-        }
-
         // insert our original document.
         // assert that, without comparing ids, our
         // inserted document equals our original document
-        val originalDocument = BsonDocument.parse(originalJson)
-        collection.insertOne(originalDocument)
+        val originalJson = """
+             {
+               "shop_name": "nkd pizza",
+               "address": {
+                 "street": "9 orwell rd",
+                 "city": "dublin 6",
+                 "county": "dublin"
+               },
+               "rating": 5,
+               "menu": [
+                 "cheese",
+                 "pepperoni",
+                 "veggie"
+               ],
+               "employees": [
+                 {
+                   "name": "aoife",
+                   "age": 26,
+                   "euro_per_hr": 18,
+                   "title": "junior employee"
+                 },
+                 {
+                   "name": "niamh",
+                   "age": 27,
+                   "euro_per_hr": 20,
+                   "title": "chef"
+                 },
+               ]
+             }
+            """
+        var beforeDocument = BsonDocument.parse(originalJson)
+        collection.insertOne(beforeDocument)
         assertEquals(
-            withoutId(originalDocument),
+            withoutId(beforeDocument),
             collection.aggregate(
                 listOf(
                     BsonDocument(
@@ -249,11 +181,149 @@ class ChangeEventUnitTests {
                         BsonDocument("_id", BsonInt32(0))
                             .append("employees", BsonDocument("_id", BsonInt32(0)))
                     ))).first())
+        var afterDocument = BsonDocument.parse("""
+             {
+               "shop_name": "nkd pizza",
+               "address": {
+                 "street": "10 orwell rd",
+                 "city": "dublin 6",
+                 "county": "dublin"
+               },
+               "menu": [
+                 "cheese",
+                 "veggie"
+               ],
+               "employees": [
+                 {
+                   "name": "aoife",
+                   "age": 26,
+                   "euro_per_hr": 18,
+                   "title": "senior employee"
+                 },
+                 {
+                   "name": "niamh",
+                   "age": 27,
+                   "euro_per_hr": 20,
+                   "title": "chef"
+                 },
+                 {
+                   "name": "alice",
+                   "age": 29,
+                   "euro_per_hr": 14,
+                   "title": "cashier"
+                 },
+               ]
+             }
+            """).append("_id", beforeDocument["_id"])
+        // 1. test general nested swaps
+        testDiff(
+            collection = collection,
+            beforeDocument = beforeDocument,
+            expectedUpdateDocument = BsonDocument.parse("""
+                {
+                    "${'$'}set": {
+                        "address.street": "10 orwell rd",
+                        "menu" : ["cheese", "veggie"],
+                        "employees" : [
+                            {
+                                "name": "aoife",
+                                "age": 26,
+                                "euro_per_hr": 18,
+                                "title" : "senior employee"
+                            },
+                            {
+                                "name": "niamh",
+                                "age": 27,
+                                "euro_per_hr": 20,
+                                "title": "chef"
+                            },
+                            {
+                                "name": "alice",
+                                "age": 29,
+                                "euro_per_hr": 14,
+                                "title": "cashier"
+                            }
+                        ]
+                    },
+                    "${'$'}unset" : {
+                        "rating": true
+                    }
+                }
+            """),
+            afterDocument = afterDocument)
+        // 2. test array to null
+        beforeDocument = afterDocument
+        afterDocument = BsonDocument.parse("""
+             {
+               "shop_name": "nkd pizza",
+               "address": {
+                 "street": "10 orwell rd",
+                 "city": "dublin 6",
+                 "county": "dublin"
+               },
+               "menu": null,
+               "employees": [
+                 {
+                   "name": "aoife",
+                   "age": 26,
+                   "euro_per_hr": 18,
+                   "title": "senior employee"
+                 },
+                 {
+                   "name": "niamh",
+                   "age": 27,
+                   "euro_per_hr": 20,
+                   "title": "chef"
+                 },
+                 {
+                   "name": "alice",
+                   "age": 29,
+                   "euro_per_hr": 14,
+                   "title": "cashier"
+                 },
+               ]
+             }
+            """).append("_id", beforeDocument["_id"])
+        testDiff(
+            collection = collection,
+            beforeDocument = beforeDocument,
+            expectedUpdateDocument = BsonDocument.parse("""
+                { "${'$'}set" : { "menu" : null } }
+            """.trimIndent()),
+            afterDocument = afterDocument)
 
-        val expectedDocumentAfterUpdate = BsonDocument.parse(expectedJson)
-        expectedDocumentAfterUpdate["_id"] = originalDocument["_id"]
-        testUpdatedDocumentMatchesExpectation(originalDocument, expectedDocumentAfterUpdate)
-        testUpdatedDocumentMatchesExpectation(expectedDocumentAfterUpdate, BsonDocument.parse(expectedJson2))
+        // 3. test doc to empty doc
+        beforeDocument = afterDocument
+        afterDocument = BsonDocument().append("_id", beforeDocument["_id"])
+        testDiff(
+            collection = collection,
+            beforeDocument = beforeDocument,
+            expectedUpdateDocument = BsonDocument.parse("""
+                {
+                    "${'$'}unset" : {
+                        "shop_name" : true,
+                        "address" : true,
+                        "menu" : true,
+                        "employees" : true
+                    }
+                }
+            """.trimIndent()),
+            afterDocument = afterDocument)
+
+        // 4. test empty to empty
+        beforeDocument = afterDocument
+        afterDocument = BsonDocument()
+        try {
+            testDiff(
+                collection = collection,
+                beforeDocument = beforeDocument,
+                expectedUpdateDocument = BsonDocument(),
+                afterDocument = afterDocument
+            )
+            fail("Should have thrown exception due to invalid bson")
+        } catch (e: IllegalArgumentException) {
+            assertNotNull(e)
+        }
 
         harness.close()
     }
@@ -270,5 +340,41 @@ class ChangeEventUnitTests {
 
         assertEquals(updatedFields, updateDoc["\$set"])
         assertEquals(removedFields, updateDoc["\$unset"]?.asDocument()?.entries?.map { it.key })
+    }
+
+    fun testDiff(
+        collection: MongoCollection<BsonDocument>,
+        beforeDocument: BsonDocument,
+        expectedUpdateDocument: BsonDocument,
+        afterDocument: BsonDocument
+    ) {
+        // create an update description via diff'ing the two documents.
+        val updateDescription = diff(withoutId(beforeDocument), withoutId(afterDocument))
+
+        assertEquals(
+            expectedUpdateDocument,
+            updateDescription.toUpdateDocument()
+        )
+
+        // create an update document from the update description.
+        // update the original document with the update document
+        collection.updateOne(BsonDocument("_id", beforeDocument.getObjectId("_id")), updateDescription.toUpdateDocument())
+
+        // assert that our newly updated document reflects our expectations
+        assertEquals(
+            withoutId(afterDocument),
+            collection.aggregate(
+                listOf(
+                    BsonDocument(
+                        "\$project",
+                        BsonDocument("_id", BsonInt32(0))
+                            .append("employees", BsonDocument("_id", BsonInt32(0)))
+                    ))).first())
+    }
+
+    private fun withoutId(document: BsonDocument): BsonDocument {
+        val newDocument = BsonDocument(document.map { BsonElement(it.key, it.value) })
+        newDocument.remove("_id")
+        return newDocument
     }
 }

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/CoreSyncUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/CoreSyncUnitTests.kt
@@ -23,7 +23,7 @@ class CoreSyncUnitTests {
 
     @After
     fun teardown() {
-        harness.teardown()
+        harness.close()
         CoreRemoteClientFactory.close()
         ServerEmbeddedMongoClientFactory.getInstance().close()
     }

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerTestContext.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerTestContext.kt
@@ -1,14 +1,19 @@
 package com.mongodb.stitch.core.services.mongodb.remote.sync.internal
 
 import com.mongodb.MongoNamespace
+import com.mongodb.client.MongoClient
 import com.mongodb.client.result.DeleteResult
 import com.mongodb.client.result.UpdateResult
+import com.mongodb.stitch.core.StitchAppClientInfo
 import com.mongodb.stitch.core.internal.net.Event
 import com.mongodb.stitch.core.services.mongodb.remote.RemoteDeleteResult
 import com.mongodb.stitch.core.services.mongodb.remote.RemoteUpdateResult
 import com.mongodb.stitch.core.services.mongodb.remote.internal.CoreRemoteMongoCollectionImpl
+import com.mongodb.stitch.server.services.mongodb.local.internal.ServerEmbeddedMongoClientFactory
 import org.bson.BsonDocument
 import org.bson.BsonValue
+import org.bson.codecs.configuration.CodecRegistries
+import org.bson.types.ObjectId
 import java.lang.Exception
 
 /**
@@ -28,6 +33,8 @@ interface DataSynchronizerTestContext {
     val collectionMock: CoreRemoteMongoCollectionImpl<BsonDocument>
     var shouldConflictBeResolvedByRemote: Boolean
     var exceptionToThrowDuringConflict: Exception?
+
+    val localClient: MongoClient
 
     /**
      * Whether or not we are online. Acts as a switch.

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerTestContext.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerTestContext.kt
@@ -10,6 +10,7 @@ import com.mongodb.stitch.core.services.mongodb.remote.RemoteUpdateResult
 import com.mongodb.stitch.core.services.mongodb.remote.internal.CoreRemoteMongoCollectionImpl
 import org.bson.BsonDocument
 import org.bson.BsonValue
+import java.io.Closeable
 import java.lang.Exception
 
 /**
@@ -20,7 +21,7 @@ import java.lang.Exception
  * Multiple instances of the testing context could result in
  * race conditions if not opened and closed properly.
  */
-interface DataSynchronizerTestContext {
+interface DataSynchronizerTestContext: Closeable {
     val namespace: MongoNamespace
     val testDocument: BsonDocument
     val testDocumentId: BsonValue

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerTestContext.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerTestContext.kt
@@ -21,7 +21,7 @@ import java.lang.Exception
  * Multiple instances of the testing context could result in
  * race conditions if not opened and closed properly.
  */
-interface DataSynchronizerTestContext: Closeable {
+interface DataSynchronizerTestContext : Closeable {
     val namespace: MongoNamespace
     val testDocument: BsonDocument
     val testDocumentId: BsonValue

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerTestContext.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerTestContext.kt
@@ -4,16 +4,12 @@ import com.mongodb.MongoNamespace
 import com.mongodb.client.MongoClient
 import com.mongodb.client.result.DeleteResult
 import com.mongodb.client.result.UpdateResult
-import com.mongodb.stitch.core.StitchAppClientInfo
 import com.mongodb.stitch.core.internal.net.Event
 import com.mongodb.stitch.core.services.mongodb.remote.RemoteDeleteResult
 import com.mongodb.stitch.core.services.mongodb.remote.RemoteUpdateResult
 import com.mongodb.stitch.core.services.mongodb.remote.internal.CoreRemoteMongoCollectionImpl
-import com.mongodb.stitch.server.services.mongodb.local.internal.ServerEmbeddedMongoClientFactory
 import org.bson.BsonDocument
 import org.bson.BsonValue
-import org.bson.codecs.configuration.CodecRegistries
-import org.bson.types.ObjectId
 import java.lang.Exception
 
 /**

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerUnitTests.kt
@@ -369,7 +369,7 @@ class DataSynchronizerUnitTests {
             expectedChangeEvent = ChangeEvent.changeEventForLocalUpdate(
                 ctx.namespace,
                 ctx.testDocumentId,
-                ctx.updateDocument,
+                ChangeEvent.UpdateDescription(BsonDocument("count", BsonInt32(2)), listOf()),
                 docAfterUpdate,
                 true
             ))
@@ -382,13 +382,24 @@ class DataSynchronizerUnitTests {
         ctx.verifyChangeEventListenerCalledForActiveDoc(times = 1, expectedChangeEvent = ChangeEvent.changeEventForLocalUpdate(
             ctx.namespace,
             ctx.testDocumentId,
-            ctx.updateDocument,
+            ChangeEvent.UpdateDescription(BsonDocument("count", BsonInt32(2)), listOf()),
             docAfterUpdate,
             false
         ))
         val docCaptor = ArgumentCaptor.forClass(BsonDocument::class.java)
         verify(ctx.collectionMock, times(1)).updateOne(any(), docCaptor.capture())
-        assertEquals(docAfterUpdate, withoutSyncVersion(docCaptor.value))
+
+        // create what we expect the diff to look like
+        val expectedDiff = ChangeEvent.UpdateDescription.diff(
+            BsonDocument.parse(ctx.testDocument.toJson()),
+            docAfterUpdate).toUpdateDocument()
+        expectedDiff.remove("\$unset")
+
+        // get the actual diff. remove the versioning info
+        val actualDiff = docCaptor.value
+        actualDiff.getDocument("\$set").remove(DataSynchronizer.DOCUMENT_VERSION_FIELD)
+
+        assertEquals(expectedDiff, actualDiff)
         ctx.verifyConflictHandlerCalledForActiveDoc(times = 0)
         ctx.verifyErrorListenerCalledForActiveDoc(times = 0)
 
@@ -406,7 +417,7 @@ class DataSynchronizerUnitTests {
         var expectedLocalEvent = ChangeEvent.changeEventForLocalUpdate(
             ctx.namespace,
             ctx.testDocumentId,
-            ctx.updateDocument,
+            ChangeEvent.UpdateDescription(BsonDocument("count", BsonInt32(2)), listOf()),
             docAfterUpdate,
             true)
 
@@ -445,7 +456,7 @@ class DataSynchronizerUnitTests {
         expectedLocalEvent = ChangeEvent.changeEventForLocalUpdate(
             ctx.namespace,
             ctx.testDocumentId,
-            ctx.updateDocument,
+            ChangeEvent.UpdateDescription(BsonDocument("count", BsonInt32(2)), listOf()),
             docAfterUpdate,
             true)
         var expectedRemoteEvent = ChangeEvent.changeEventForLocalDelete(ctx.namespace, ctx.testDocumentId, false)
@@ -489,7 +500,7 @@ class DataSynchronizerUnitTests {
         expectedLocalEvent = ChangeEvent.changeEventForLocalUpdate(
             ctx.namespace,
             ctx.testDocumentId,
-            ctx.updateDocument,
+            ChangeEvent.UpdateDescription(BsonDocument("count", BsonInt32(2)), listOf()),
             docAfterUpdate,
             true)
         expectedRemoteEvent = ChangeEvent.changeEventForLocalDelete(ctx.namespace, ctx.testDocumentId, false)
@@ -556,7 +567,7 @@ class DataSynchronizerUnitTests {
         val expectedEvent = ChangeEvent.changeEventForLocalUpdate(
             ctx.namespace,
             ctx.testDocument["_id"],
-            ctx.updateDocument,
+            ChangeEvent.UpdateDescription(BsonDocument("count", BsonInt32(2)), listOf()),
             docAfterUpdate,
             true
         )
@@ -578,7 +589,18 @@ class DataSynchronizerUnitTests {
         ctx.waitForError()
         val docCaptor = ArgumentCaptor.forClass(BsonDocument::class.java)
         verify(ctx.collectionMock, times(1)).updateOne(any(), docCaptor.capture())
-        assertEquals(expectedEvent.fullDocument, withoutSyncVersion(docCaptor.value))
+
+        // create what we expect the diff to look like
+        val expectedDiff = ChangeEvent.UpdateDescription.diff(
+            BsonDocument.parse(ctx.testDocument.toJson()),
+            expectedEvent.fullDocument).toUpdateDocument()
+        expectedDiff.remove("\$unset")
+
+        // get the actual diff. remove the versioning info
+        val actualDiff = docCaptor.value
+        actualDiff.getDocument("\$set").remove(DataSynchronizer.DOCUMENT_VERSION_FIELD)
+
+        assertEquals(expectedDiff, actualDiff)
         ctx.verifyChangeEventListenerCalledForActiveDoc(times = 0)
         ctx.verifyConflictHandlerCalledForActiveDoc(times = 0)
         ctx.verifyErrorListenerCalledForActiveDoc(times = 1, error = expectedException)
@@ -667,7 +689,7 @@ class DataSynchronizerUnitTests {
             false
         ))
         ctx.verifyConflictHandlerCalledForActiveDoc(1, expectedLocalEvent,
-            ChangeEvent.changeEventForLocalUpdate(ctx.namespace, ctx.testDocumentId, ctx.updateDocument, ctx.testDocument, false))
+            ChangeEvent.changeEventForLocalUpdate(ctx.namespace, ctx.testDocumentId, null, ctx.testDocument, false))
         ctx.verifyErrorListenerCalledForActiveDoc(0)
 
         assertEquals(
@@ -707,7 +729,7 @@ class DataSynchronizerUnitTests {
         ctx.verifyConflictHandlerCalledForActiveDoc(1,
             ChangeEvent.changeEventForLocalDelete(ctx.namespace, ctx.testDocumentId, true),
             ChangeEvent.changeEventForLocalUpdate(
-                ctx.namespace, ctx.testDocumentId, ctx.updateDocument, ctx.testDocument, false
+                ctx.namespace, ctx.testDocumentId, null, ctx.testDocument, false
             ))
         ctx.verifyErrorListenerCalledForActiveDoc(0)
 
@@ -803,7 +825,7 @@ class DataSynchronizerUnitTests {
         ctx.verifyChangeEventListenerCalledForActiveDoc(
             1,
             ChangeEvent.changeEventForLocalUpdate(
-                ctx.namespace, ctx.testDocumentId, ctx.updateDocument, expectedDocumentAfterUpdate, true))
+                ctx.namespace, ctx.testDocumentId, ChangeEvent.UpdateDescription(BsonDocument("count", BsonInt32(2)), listOf()), expectedDocumentAfterUpdate, true))
         // assert that the updated document equals what we've expected
         assertEquals(ctx.testDocument["_id"], ctx.findTestDocumentFromLocalCollection()?.get("_id"))
         assertEquals(expectedDocumentAfterUpdate, ctx.findTestDocumentFromLocalCollection()!!)

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerUnitTests.kt
@@ -71,7 +71,7 @@ class DataSynchronizerUnitTests {
 
     @After
     fun teardown() {
-        harness.teardown()
+        harness.close()
         CoreRemoteClientFactory.close()
         ServerEmbeddedMongoClientFactory.getInstance().close()
     }

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
@@ -47,7 +47,7 @@ import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
 import java.util.Random
 
-class SyncUnitTestHarness {
+class SyncUnitTestHarness: AutoCloseable {
     companion object {
         /**
          * Conflict handler used for testing purposes.
@@ -509,6 +509,10 @@ class SyncUnitTestHarness {
             }
         }
 
+        override fun close() {
+            dataSynchronizer.close()
+        }
+
         private fun configureNewErrorListener() {
             val emitErrorSemaphore = Semaphore(0)
             this.errorSemaphore?.release()
@@ -533,7 +537,7 @@ class SyncUnitTestHarness {
 
     private var latestCtx: DataSynchronizerTestContext? = null
 
-    internal fun teardown() {
+    override fun close() {
         latestCtx?.dataSynchronizer?.close()
     }
 

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
@@ -48,7 +48,7 @@ import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
 import java.util.Random
 
-class SyncUnitTestHarness: Closeable {
+class SyncUnitTestHarness : Closeable {
     companion object {
         /**
          * Conflict handler used for testing purposes.

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
@@ -1,6 +1,7 @@
 package com.mongodb.stitch.core.services.mongodb.remote.sync.internal
 
 import com.mongodb.MongoNamespace
+import com.mongodb.client.MongoClient
 import com.mongodb.client.result.DeleteResult
 import com.mongodb.client.result.UpdateResult
 import com.mongodb.stitch.core.StitchAppClientInfo
@@ -266,7 +267,7 @@ class SyncUnitTestHarness {
         val networkMonitor: TestNetworkMonitor = spy(TestNetworkMonitor())
         val authMonitor: TestAuthMonitor = spy(TestAuthMonitor())
 
-        private val localClient by lazy {
+        override val localClient: MongoClient by lazy {
             val clientKey = ObjectId().toHexString()
             SyncMongoClientFactory.getClient(
                 StitchAppClientInfo(
@@ -400,7 +401,7 @@ class SyncUnitTestHarness {
 
         override fun queueConsumableRemoteUpdateEvent() {
             `when`(dataSynchronizer.getEventsForNamespace(any())).thenReturn(
-                mapOf(testDocument to ChangeEvent.changeEventForLocalUpdate(namespace, testDocumentId, updateDocument, testDocument, false)),
+                mapOf(testDocument to ChangeEvent.changeEventForLocalUpdate(namespace, testDocumentId, null, testDocument, false)),
                 mapOf())
         }
 

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
@@ -42,12 +42,13 @@ import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
+import java.io.Closeable
 import java.lang.Exception
 import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
 import java.util.Random
 
-class SyncUnitTestHarness: AutoCloseable {
+class SyncUnitTestHarness: Closeable {
     companion object {
         /**
          * Conflict handler used for testing purposes.

--- a/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/BaseStitchIntTest.kt
+++ b/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/BaseStitchIntTest.kt
@@ -124,6 +124,6 @@ abstract class BaseStitchIntTest {
     }
 
     fun addRule(svc: Service, config: RuleCreator): RuleResponse {
-        return svc.rules.create(config)
+        return svc.rules.create(data = config)
     }
 }

--- a/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
+++ b/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
@@ -1292,7 +1292,8 @@ class SyncIntTestProxy(private val syncTestRunner: SyncIntTestRunner) {
 
             val eventSemaphore = Semaphore(0)
             coll.configure(failingConflictHandler, ChangeEventListener { _, event ->
-                if (!event.hasUncommittedWrites()) {
+                if (event.operationType == ChangeEvent.OperationType.UPDATE
+                    && !event.hasUncommittedWrites()) {
                     assertEquals(
                         updateDoc["\$set"],
                         event.updateDescription.updatedFields)

--- a/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
+++ b/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
@@ -1291,7 +1291,7 @@ class SyncIntTestProxy(private val syncTestRunner: SyncIntTestRunner) {
             val doc1Filter = Document("_id", doc1Id)
 
             val eventSemaphore = Semaphore(0)
-            coll.configure(failingConflictHandler, ChangeEventListener { documentId, event ->
+            coll.configure(failingConflictHandler, ChangeEventListener { _, event ->
                 assertEquals(
                     updateDoc["\$set"],
                     event.updateDescription.updatedFields)

--- a/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
+++ b/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
@@ -1,14 +1,10 @@
 package com.mongodb.stitch.core.testutils.sync
 
 import com.mongodb.MongoNamespace
-import com.mongodb.stitch.core.admin.Apps
 import com.mongodb.stitch.core.admin.create
-import com.mongodb.stitch.core.admin.get
-import com.mongodb.stitch.core.admin.list
 import com.mongodb.stitch.core.admin.remove
 import com.mongodb.stitch.core.admin.services.rules.RuleCreator
 import com.mongodb.stitch.core.admin.services.rules.rule
-import com.mongodb.stitch.core.admin.update
 import com.mongodb.stitch.core.internal.common.Callback
 import com.mongodb.stitch.core.internal.common.OperationResult
 import com.mongodb.stitch.core.services.mongodb.remote.sync.ChangeEventListener

--- a/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
+++ b/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
@@ -841,7 +841,7 @@ class SyncIntTestProxy(private val syncTestRunner: SyncIntTestRunner) {
             val remoteColl = syncTestRunner.remoteMethods()
 
             // insert a new document remotely
-            val docToInsert = Document("_id", "hello")
+            val docToInsert = Document()
             remoteColl.insertOne(docToInsert)
 
             // configure Sync to resolve a custom document when handling a conflict

--- a/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
+++ b/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
@@ -1292,8 +1292,8 @@ class SyncIntTestProxy(private val syncTestRunner: SyncIntTestRunner) {
 
             val eventSemaphore = Semaphore(0)
             coll.configure(failingConflictHandler, ChangeEventListener { _, event ->
-                if (event.operationType == ChangeEvent.OperationType.UPDATE
-                    && !event.hasUncommittedWrites()) {
+                if (event.operationType == ChangeEvent.OperationType.UPDATE &&
+                    !event.hasUncommittedWrites()) {
                     assertEquals(
                         updateDoc["\$set"],
                         event.updateDescription.updatedFields)

--- a/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
+++ b/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
@@ -1411,11 +1411,6 @@ class SyncIntTestProxy(private val syncTestRunner: SyncIntTestRunner) {
         throw IllegalStateException("unreachable")
     }
 
-    private val failingErrorListener = ErrorListener { _: BsonValue, error: Exception ->
-        Assert.fail("did not expect an error: ${error.message}")
-        throw IllegalStateException("unreachable")
-    }
-
     private fun testSyncInBothDirections(testFun: () -> Unit) {
         println("running tests with L2R going first")
         syncTestRunner.dataSynchronizer.swapSyncDirection(true)

--- a/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestRunner.kt
+++ b/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestRunner.kt
@@ -2,7 +2,6 @@ package com.mongodb.stitch.core.testutils.sync
 
 import com.mongodb.MongoNamespace
 import com.mongodb.stitch.core.admin.Apps
-import com.mongodb.stitch.core.admin.services.rules.RuleCreator
 import com.mongodb.stitch.core.admin.services.rules.RuleResponse
 import com.mongodb.stitch.core.services.mongodb.remote.sync.internal.DataSynchronizer
 import com.mongodb.stitch.core.testutils.BaseStitchIntTest

--- a/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestRunner.kt
+++ b/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestRunner.kt
@@ -1,6 +1,9 @@
 package com.mongodb.stitch.core.testutils.sync
 
 import com.mongodb.MongoNamespace
+import com.mongodb.stitch.core.admin.Apps
+import com.mongodb.stitch.core.admin.services.rules.RuleCreator
+import com.mongodb.stitch.core.admin.services.rules.RuleResponse
 import com.mongodb.stitch.core.services.mongodb.remote.sync.internal.DataSynchronizer
 import com.mongodb.stitch.core.testutils.BaseStitchIntTest
 import org.junit.After
@@ -34,6 +37,8 @@ interface SyncIntTestRunner {
      */
     val namespace: MongoNamespace
 
+    var mdbService: Apps.App.Services.Service
+    var mdbRule: RuleResponse
     /**
      * A series of remote methods, independent of platform,
      * that have been normalized for testing.
@@ -128,4 +133,7 @@ interface SyncIntTestRunner {
 
     @Test
     fun testStaleFetchMultiple()
+
+    @Test
+    fun testShouldUpdateUsingUpdateDescription()
 }

--- a/server/services/mongodb-remote/src/test/java/com/mongodb/stitch/server/services/mongodb/remote/RemoteMongoClientIntTests.kt
+++ b/server/services/mongodb-remote/src/test/java/com/mongodb/stitch/server/services/mongodb/remote/RemoteMongoClientIntTests.kt
@@ -58,12 +58,14 @@ class RemoteMongoClientIntTests : BaseStitchServerIntTest() {
                 "mongodb1",
                 ServiceConfigs.Mongo(getMongoDbUri()))
 
-        val rule = Document()
-        rule["read"] = Document()
-        rule["write"] = Document()
-        rule["other_fields"] = Document()
-
-        addRule(svc.second, RuleCreator.MongoDb("$dbName.$collName", rule))
+        val rule = RuleCreator.MongoDb(
+            database = dbName,
+            collection = collName,
+            roles = listOf(RuleCreator.MongoDb.Role(
+                read = true, write = true
+            )),
+            schema = RuleCreator.MongoDb.Schema())
+        addRule(svc.second, rule)
 
         val client = getAppClient(app.first)
         client.auth.loginWithCredential(AnonymousCredential())


### PR DESCRIPTION
See https://docs.google.com/document/d/1lvd02JFNI9Aa7Zely3xMJEct_N-HMn84tKIIhMq7Zes/ for more detailed information on the agreed design.

- Add additional logic for creating v2 rules for MongoDB. Make setting rules easier, which is handy for integration tests.
