### PR TITLE
STITCH-2133 Add ability to unfreeze document via sync

### DIFF
--- a/android/services/mongodb-remote/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/remote/internal/SyncMongoClientIntTests.kt
+++ b/android/services/mongodb-remote/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/remote/internal/SyncMongoClientIntTests.kt
@@ -98,6 +98,10 @@ class SyncMongoClientIntTests : BaseStitchAndroidIntTest(), SyncIntTestRunner {
         override fun find(filter: Bson): Iterable<Document?> {
             return Tasks.await(sync.find(filter).into(mutableListOf<Document>()))
         }
+
+        override fun resumeSyncForDocument(documentId: BsonValue): Boolean {
+            return sync.resumeSyncForDocument(documentId)
+        }
     }
 
     private var dbName = ObjectId().toHexString()
@@ -271,7 +275,7 @@ class SyncMongoClientIntTests : BaseStitchAndroidIntTest(), SyncIntTestRunner {
 
     @Test
     override fun testFrozenDocumentConfig() {
-        testProxy.testFrozenDocumentConfig()
+        testProxy.testPausedDocumentConfig()
     }
 
     @Test
@@ -306,6 +310,11 @@ class SyncMongoClientIntTests : BaseStitchAndroidIntTest(), SyncIntTestRunner {
     @Test
     override fun testShouldUpdateUsingUpdateDescription() {
         testProxy.testShouldUpdateUsingUpdateDescription()
+    }
+
+    @Test
+    override fun testResumeSyncForDocumentResumesSync() {
+        testProxy.testResumeSyncForDocumentResumesSync()
     }
 
     /**

--- a/android/services/mongodb-remote/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/remote/internal/SyncMongoClientIntTests.kt
+++ b/android/services/mongodb-remote/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/remote/internal/SyncMongoClientIntTests.kt
@@ -274,7 +274,7 @@ class SyncMongoClientIntTests : BaseStitchAndroidIntTest(), SyncIntTestRunner {
     }
 
     @Test
-    override fun testFrozenDocumentConfig() {
+    override fun testPausedDocumentConfig() {
         testProxy.testPausedDocumentConfig()
     }
 

--- a/android/services/mongodb-remote/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/remote/internal/SyncMongoClientIntTests.kt
+++ b/android/services/mongodb-remote/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/remote/internal/SyncMongoClientIntTests.kt
@@ -102,6 +102,10 @@ class SyncMongoClientIntTests : BaseStitchAndroidIntTest(), SyncIntTestRunner {
         override fun resumeSyncForDocument(documentId: BsonValue): Boolean {
             return sync.resumeSyncForDocument(documentId)
         }
+
+        override fun getPausedDocumentIds(): Set<BsonValue> {
+            return sync.pausedDocumentIds
+        }
     }
 
     private var dbName = ObjectId().toHexString()

--- a/android/services/mongodb-remote/src/main/java/com/mongodb/stitch/android/services/mongodb/remote/Sync.java
+++ b/android/services/mongodb-remote/src/main/java/com/mongodb/stitch/android/services/mongodb/remote/Sync.java
@@ -84,6 +84,14 @@ public interface Sync<DocumentT> {
   Set<BsonValue> getSyncedIds();
 
   /**
+   * Return the set of synchronized document _ids in a namespace
+   * that have been paused due to an irrecoverable error.
+   *
+   * @return the set of paused document _ids in a namespace
+   */
+  Set<BsonValue> getPausedDocumentIds();
+
+  /**
    * A document that is paused no longer has remote updates applied to it.
    * Any local updates to this document cause it to be resumed. An example of pausing a document
    * is when a conflict is being resolved for that document and the handler throws an exception.

--- a/android/services/mongodb-remote/src/main/java/com/mongodb/stitch/android/services/mongodb/remote/Sync.java
+++ b/android/services/mongodb-remote/src/main/java/com/mongodb/stitch/android/services/mongodb/remote/Sync.java
@@ -84,6 +84,15 @@ public interface Sync<DocumentT> {
   Set<BsonValue> getSyncedIds();
 
   /**
+   * Unfreeze a document.
+   *
+   * @param documentId the id of the document to unfreeze
+   * @return true if successfully unfrozen, false if the document
+   *         could not be found or there was an error unfreezing
+   */
+  boolean unfreezeDocument(final BsonValue documentId);
+
+  /**
    * Finds all documents in the collection that have been synchronized from the remote.
    *
    * @return the find iterable interface

--- a/android/services/mongodb-remote/src/main/java/com/mongodb/stitch/android/services/mongodb/remote/Sync.java
+++ b/android/services/mongodb-remote/src/main/java/com/mongodb/stitch/android/services/mongodb/remote/Sync.java
@@ -84,13 +84,15 @@ public interface Sync<DocumentT> {
   Set<BsonValue> getSyncedIds();
 
   /**
-   * Unfreeze a document.
+   * A document that is paused no longer has remote updates applied to it.
+   * Any local updates to this document cause it to be resumed. An example of pausing a document
+   * is when a conflict is being resolved for that document and the handler throws an exception.
    *
-   * @param documentId the id of the document to unfreeze
-   * @return true if successfully unfrozen, false if the document
-   *         could not be found or there was an error unfreezing
+   * @param documentId the id of the document to resume syncing
+   * @return true if successfully resumed, false if the document
+   *         could not be found or there was an error resuming
    */
-  boolean unfreezeDocument(final BsonValue documentId);
+  boolean resumeSyncForDocument(@NonNull final BsonValue documentId);
 
   /**
    * Finds all documents in the collection that have been synchronized from the remote.

--- a/android/services/mongodb-remote/src/main/java/com/mongodb/stitch/android/services/mongodb/remote/internal/SyncImpl.java
+++ b/android/services/mongodb-remote/src/main/java/com/mongodb/stitch/android/services/mongodb/remote/internal/SyncImpl.java
@@ -80,6 +80,11 @@ public class SyncImpl<DocumentT> implements Sync<DocumentT> {
   }
 
   @Override
+  public Set<BsonValue> getPausedDocumentIds() {
+    return this.proxy.getPausedDocumentIds();
+  }
+
+  @Override
   public boolean resumeSyncForDocument(@NonNull final BsonValue documentId) {
     return this.proxy.resumeSyncForDocument(documentId);
   }

--- a/android/services/mongodb-remote/src/main/java/com/mongodb/stitch/android/services/mongodb/remote/internal/SyncImpl.java
+++ b/android/services/mongodb-remote/src/main/java/com/mongodb/stitch/android/services/mongodb/remote/internal/SyncImpl.java
@@ -80,8 +80,8 @@ public class SyncImpl<DocumentT> implements Sync<DocumentT> {
   }
 
   @Override
-  public boolean unfreezeDocument(final BsonValue documentId) {
-    return this.proxy.unfreezeDocument(documentId);
+  public boolean resumeSyncForDocument(@NonNull final BsonValue documentId) {
+    return this.proxy.resumeSyncForDocument(documentId);
   }
 
   @Override

--- a/android/services/mongodb-remote/src/main/java/com/mongodb/stitch/android/services/mongodb/remote/internal/SyncImpl.java
+++ b/android/services/mongodb-remote/src/main/java/com/mongodb/stitch/android/services/mongodb/remote/internal/SyncImpl.java
@@ -80,6 +80,11 @@ public class SyncImpl<DocumentT> implements Sync<DocumentT> {
   }
 
   @Override
+  public boolean unfreezeDocument(final BsonValue documentId) {
+    return this.proxy.unfreezeDocument(documentId);
+  }
+
+  @Override
   public SyncFindIterable<DocumentT> find() {
     return new SyncFindIterableImpl<>(proxy.find(), dispatcher);
   }

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/CoreSync.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/CoreSync.java
@@ -80,13 +80,15 @@ public interface CoreSync<DocumentT> {
   Set<BsonValue> getSyncedIds();
 
   /**
-   * Unfreeze a document.
+   * A document that is paused no longer has remote updates applied to it.
+   * Any local updates to this document cause it to be resumed. An example of pausing a document
+   * is when a conflict is being resolved for that document and the handler throws an exception.
    *
-   * @param documentId the id of the document to unfreeze
-   * @return true if successfully unfrozen, false if the document
-   *         could not be found or there was an error unfreezing
+   * @param documentId the id of the document to resume syncing
+   * @return true if successfully resumed, false if the document
+   *         could not be found or there was an error resuming
    */
-  boolean unfreezeDocument(final BsonValue documentId);
+  boolean resumeSyncForDocument(final BsonValue documentId);
 
   /**
    * Finds all documents in the collection that have been synchronized from the remote.

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/CoreSync.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/CoreSync.java
@@ -80,6 +80,14 @@ public interface CoreSync<DocumentT> {
   Set<BsonValue> getSyncedIds();
 
   /**
+   * Return the set of synchronized document _ids in a namespace
+   * that have been paused due to an irrecoverable error.
+   *
+   * @return the set of paused document _ids in a namespace
+   */
+  Set<BsonValue> getPausedDocumentIds();
+
+  /**
    * A document that is paused no longer has remote updates applied to it.
    * Any local updates to this document cause it to be resumed. An example of pausing a document
    * is when a conflict is being resolved for that document and the handler throws an exception.

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/CoreSync.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/CoreSync.java
@@ -80,6 +80,15 @@ public interface CoreSync<DocumentT> {
   Set<BsonValue> getSyncedIds();
 
   /**
+   * Unfreeze a document.
+   *
+   * @param documentId the id of the document to unfreeze
+   * @return true if successfully unfrozen, false if the document
+   *         could not be found or there was an error unfreezing
+   */
+  boolean unfreezeDocument(final BsonValue documentId);
+
+  /**
    * Finds all documents in the collection that have been synchronized from the remote.
    *
    * @return the find iterable interface

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/CoreSyncImpl.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/CoreSyncImpl.java
@@ -98,6 +98,11 @@ public class CoreSyncImpl<DocumentT> implements CoreSync<DocumentT> {
   }
 
   @Override
+  public Set<BsonValue> getPausedDocumentIds() {
+    return this.dataSynchronizer.getPausedDocumentIds(namespace);
+  }
+
+  @Override
   public boolean resumeSyncForDocument(final BsonValue documentId) {
     return this.dataSynchronizer.resumeSyncForDocument(namespace, documentId);
   }

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/CoreSyncImpl.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/CoreSyncImpl.java
@@ -98,6 +98,18 @@ public class CoreSyncImpl<DocumentT> implements CoreSync<DocumentT> {
   }
 
   /**
+   * Unfreeze a document.
+   *
+   * @param documentId the id of the document to unfreeze
+   * @return true if successfully unfrozen, false if the document
+   *         could not be found or there was an error unfreezing
+   */
+  @Override
+  public boolean unfreezeDocument(final BsonValue documentId) {
+    return this.dataSynchronizer.unfreezeDocument(namespace, documentId);
+  }
+
+  /**
    * Finds a single document by the given id. It is first searched for in the local synchronized
    * cache and if not found and there is internet connectivity, it is searched for remotely.
    *

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/CoreSyncImpl.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/CoreSyncImpl.java
@@ -97,16 +97,9 @@ public class CoreSyncImpl<DocumentT> implements CoreSync<DocumentT> {
     return this.dataSynchronizer.getSynchronizedDocumentIds(namespace);
   }
 
-  /**
-   * Unfreeze a document.
-   *
-   * @param documentId the id of the document to unfreeze
-   * @return true if successfully unfrozen, false if the document
-   *         could not be found or there was an error unfreezing
-   */
   @Override
-  public boolean unfreezeDocument(final BsonValue documentId) {
-    return this.dataSynchronizer.unfreezeDocument(namespace, documentId);
+  public boolean resumeSyncForDocument(final BsonValue documentId) {
+    return this.dataSynchronizer.resumeSyncForDocument(namespace, documentId);
   }
 
   /**

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
@@ -1533,6 +1533,7 @@ public class DataSynchronizer implements NetworkMonitor.StateListener {
    *
    * This method allows you to resume sync for a document.
    *
+   * @param namespace namespace for the document
    * @param documentId the id of the document to resume syncing
    * @return true if successfully resumed, false if the document
    *         could not be found or there was an error resuming

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
@@ -1527,6 +1527,32 @@ public class DataSynchronizer implements NetworkMonitor.StateListener {
     triggerListeningToNamespace(namespace);
   }
 
+  /**
+   * Unfreeze a document.
+   *
+   * @param documentId the id of the document to unfreeze
+   * @return true if successfully unfrozen, false if the document
+   *         could not be found or there was an error unfreezing
+   */
+  boolean unfreezeDocument(
+      final MongoNamespace namespace,
+      final BsonValue documentId
+  ) {
+    final NamespaceSynchronizationConfig namespaceSynchronizationConfig =
+        syncConfig.getNamespaceConfig(namespace);
+    if (namespaceSynchronizationConfig == null) {
+      return false;
+    }
+
+    final CoreDocumentSynchronizationConfig config =
+        namespaceSynchronizationConfig.getSynchronizedDocument(documentId);
+    if (config == null) {
+      return false;
+    }
+    config.setFrozen(false);
+    return !config.isFrozen();
+  }
+
   public <T> Collection<T> find(
       final MongoNamespace namespace,
       final BsonDocument filter,

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
@@ -430,7 +430,7 @@ public class DataSynchronizer implements NetworkMonitor.StateListener {
         final CoreDocumentSynchronizationConfig docConfig =
             nsConfig.getSynchronizedDocument(eventEntry.getKey().asDocument().get("_id"));
 
-        if (docConfig == null || docConfig.isFrozen()) {
+        if (docConfig == null || docConfig.isPaused()) {
           // Not interested in this event.
           continue;
         }
@@ -446,7 +446,7 @@ public class DataSynchronizer implements NetworkMonitor.StateListener {
       for (final BsonValue docId : unseenIds) {
         final CoreDocumentSynchronizationConfig docConfig =
             nsConfig.getSynchronizedDocument(docId);
-        if (docConfig == null || docConfig.isFrozen()) {
+        if (docConfig == null || docConfig.isPaused()) {
           // means we aren't actually synchronizing on this remote doc
           continue;
         }
@@ -475,7 +475,7 @@ public class DataSynchronizer implements NetworkMonitor.StateListener {
             nsConfig.getSynchronizedDocument(unseenId);
         if (docConfig == null
             || docConfig.getLastKnownRemoteVersion() == null
-            || docConfig.isFrozen()) {
+            || docConfig.isPaused()) {
           // means we aren't actually synchronizing on this remote doc
           continue;
         }
@@ -812,7 +812,7 @@ public class DataSynchronizer implements NetworkMonitor.StateListener {
 
       // a. For each document that has local writes pending
       for (final CoreDocumentSynchronizationConfig docConfig : nsConfig) {
-        if (!docConfig.hasUncommittedWrites() || docConfig.isFrozen()) {
+        if (!docConfig.hasUncommittedWrites() || docConfig.isPaused()) {
           continue;
         }
         if (docConfig.getLastResolution() == logicalT) {
@@ -1213,7 +1213,7 @@ public class DataSynchronizer implements NetworkMonitor.StateListener {
       });
     }
 
-    docConfig.setFrozen(true);
+    docConfig.setPaused(true);
 
     this.logger.error(msg);
     this.logger.error(
@@ -1527,29 +1527,34 @@ public class DataSynchronizer implements NetworkMonitor.StateListener {
   }
 
   /**
-   * Unfreeze a document.
+   * A document that is paused no longer has remote updates applied to it.
+   * Any local updates to this document cause it to be resumed. An example of pausing a document
+   * is when a conflict is being resolved for that document and the handler throws an exception.
    *
-   * @param documentId the id of the document to unfreeze
-   * @return true if successfully unfrozen, false if the document
-   *         could not be found or there was an error unfreezing
+   * This method allows you to resume sync for a document.
+   *
+   * @param documentId the id of the document to resume syncing
+   * @return true if successfully resumed, false if the document
+   *         could not be found or there was an error resuming
    */
-  boolean unfreezeDocument(
+  boolean resumeSyncForDocument(
       final MongoNamespace namespace,
       final BsonValue documentId
   ) {
-    final NamespaceSynchronizationConfig namespaceSynchronizationConfig =
-        syncConfig.getNamespaceConfig(namespace);
-    if (namespaceSynchronizationConfig == null) {
+    if (namespace == null || documentId == null) {
       return false;
     }
 
-    final CoreDocumentSynchronizationConfig config =
-        namespaceSynchronizationConfig.getSynchronizedDocument(documentId);
-    if (config == null) {
+    final NamespaceSynchronizationConfig namespaceSynchronizationConfig;
+    final CoreDocumentSynchronizationConfig config;
+
+    if ((namespaceSynchronizationConfig = syncConfig.getNamespaceConfig(namespace)) == null
+        || (config = namespaceSynchronizationConfig.getSynchronizedDocument(documentId)) == null) {
       return false;
     }
-    config.setFrozen(false);
-    return !config.isFrozen();
+
+    config.setPaused(false);
+    return !config.isPaused();
   }
 
   public <T> Collection<T> find(

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
@@ -1497,6 +1497,26 @@ public class DataSynchronizer implements NetworkMonitor.StateListener {
   }
 
   /**
+   * Return the set of synchronized document _ids in a namespace
+   * that have been paused due to an irrecoverable error.
+   *
+   * @param namespace the namespace to get paused document _ids for.
+   * @return the set of paused document _ids in a namespace
+   */
+  public Set<BsonValue> getPausedDocumentIds(final MongoNamespace namespace) {
+    final Set<BsonValue> pausedDocumentIds = new HashSet<>();
+
+    for (final CoreDocumentSynchronizationConfig config :
+        this.syncConfig.getSynchronizedDocuments(namespace)) {
+      if (config.isPaused()) {
+        pausedDocumentIds.add(config.getDocumentId());
+      }
+    }
+
+    return pausedDocumentIds;
+  }
+
+  /**
    * Requests that a document be synchronized by the given _id. Actual synchronization of the
    * document will happen later in a {@link DataSynchronizer#doSyncPass()} iteration.
    *

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/CoreDocumentSynchronizationConfigUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/CoreDocumentSynchronizationConfigUnitTests.kt
@@ -87,7 +87,7 @@ class CoreDocumentSynchronizationConfigUnitTests {
             1,
             expectedTestVersion,
             expectedEvent)
-        config.isFrozen = true
+        config.isPaused = true
         config.isStale = true
 
         val doc = config.toBsonDocument()
@@ -95,7 +95,7 @@ class CoreDocumentSynchronizationConfigUnitTests {
         assertEquals(id, doc[CoreDocumentSynchronizationConfig.ConfigCodec.Fields.DOCUMENT_ID_FIELD])
 
         assertTrue(doc.getBoolean(CoreDocumentSynchronizationConfig.ConfigCodec.Fields.IS_STALE).value)
-        assertTrue(doc.getBoolean(CoreDocumentSynchronizationConfig.ConfigCodec.Fields.IS_FROZEN).value)
+        assertTrue(doc.getBoolean(CoreDocumentSynchronizationConfig.ConfigCodec.Fields.IS_PAUSED).value)
         assertEquals(expectedTestVersion,
             doc[CoreDocumentSynchronizationConfig.ConfigCodec.Fields.LAST_KNOWN_REMOTE_VERSION_FIELD])
         assertEquals(
@@ -105,7 +105,7 @@ class CoreDocumentSynchronizationConfigUnitTests {
 
         config = CoreDocumentSynchronizationConfig.fromBsonDocument(doc)
 
-        assertTrue(config.isFrozen)
+        assertTrue(config.isPaused)
         assertEquals(namespace, config.namespace)
         assertEquals(expectedTestVersion, config.lastKnownRemoteVersion)
         compareEvents(expectedEvent, config.lastUncommittedChangeEvent)

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerUnitTests.kt
@@ -925,10 +925,9 @@ class DataSynchronizerUnitTests {
         ctx.doSyncPass()
 
         // assert that the doc is paused
-        assertTrue(
-            ctx.dataSynchronizer
-                .getSynchronizedDocuments(ctx.namespace)
-                .firstOrNull()?.isPaused ?: false)
+        assertEquals(
+            ctx.testDocumentId,
+            ctx.dataSynchronizer.getPausedDocumentIds(ctx.namespace).firstOrNull())
 
         // attempt a remote delete, which should fail
         ctx.queueConsumableRemoteDeleteEvent()
@@ -937,6 +936,7 @@ class DataSynchronizerUnitTests {
 
         // assert that resume returns true for our paused doc
         assertTrue(ctx.dataSynchronizer.resumeSyncForDocument(ctx.namespace, ctx.testDocumentId))
+        assertTrue(ctx.dataSynchronizer.getPausedDocumentIds(ctx.namespace).isEmpty())
 
         // queue another remote delete, one that should work
         // now that the document is no longer paused

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerUnitTests.kt
@@ -210,7 +210,7 @@ class DataSynchronizerUnitTests {
         ctx.verifyConflictHandlerCalledForActiveDoc(times = 1)
         ctx.verifyErrorListenerCalledForActiveDoc(times = 1, error = ctx.exceptionToThrowDuringConflict)
 
-        // assert that the local doc is the same. this is frozen now
+        // assert that the local doc is the same. this is paused now
         assertEquals(ctx.testDocument, ctx.findTestDocumentFromLocalCollection())
 
         ctx.exceptionToThrowDuringConflict = null
@@ -240,7 +240,7 @@ class DataSynchronizerUnitTests {
         ctx.insertTestDocument()
         ctx.waitForEvent()
 
-        // sync, verifying that the expected exceptionToThrow was emitted, freezing the document
+        // sync, verifying that the expected exceptionToThrow was emitted, pausing the document
         ctx.doSyncPass()
         ctx.waitForError()
         ctx.verifyChangeEventListenerCalledForActiveDoc(times = 0)
@@ -249,7 +249,7 @@ class DataSynchronizerUnitTests {
         assertEquals(ctx.testDocument, ctx.findTestDocumentFromLocalCollection())
 
         // prepare a remote delete event, sync, and assert that nothing was affecting
-        // (since we're frozen)
+        // (since we're paused)
         ctx.queueConsumableRemoteDeleteEvent()
         ctx.doSyncPass()
         assertEquals(ctx.testDocument, ctx.findTestDocumentFromLocalCollection())
@@ -318,7 +318,7 @@ class DataSynchronizerUnitTests {
         assertEquals(expectedDoc, ctx.findTestDocumentFromLocalCollection())
 
         // clear issues. open a path for a delete.
-        // do another sync pass. the doc should remain the same as it is frozen
+        // do another sync pass. the doc should remain the same as it is paused
         ctx.exceptionToThrowDuringConflict = null
         ctx.shouldConflictBeResolvedByRemote = false
         ctx.doSyncPass()
@@ -340,7 +340,7 @@ class DataSynchronizerUnitTests {
         ctx.doSyncPass()
         assertEquals(expectedDoc, ctx.findTestDocumentFromLocalCollection())
 
-        // should be frozen since the operation type was unknown
+        // should be paused since the operation type was unknown
         ctx.queueConsumableRemoteUnknownEvent()
         ctx.doSyncPass()
         assertEquals(expectedDoc, ctx.findTestDocumentFromLocalCollection())
@@ -530,11 +530,11 @@ class DataSynchronizerUnitTests {
         ctx.verifyConflictHandlerCalledForActiveDoc(1, expectedLocalEvent, expectedRemoteEvent)
         ctx.verifyErrorListenerCalledForActiveDoc(1, ctx.exceptionToThrowDuringConflict)
 
-        // assert that this document is still the locally updated doc. this is frozen now
+        // assert that this document is still the locally updated doc. this is paused now
         assertEquals(docAfterUpdate, ctx.findTestDocumentFromLocalCollection())
 
         // clear issues. open a path for a delete.
-        // do another sync pass. the doc should remain the same as it is frozen
+        // do another sync pass. the doc should remain the same as it is paused
         ctx.exceptionToThrowDuringConflict = null
         ctx.shouldConflictBeResolvedByRemote = false
 
@@ -553,7 +553,7 @@ class DataSynchronizerUnitTests {
         ctx.doSyncPass()
         assertEquals(ctx.testDocument, ctx.findTestDocumentFromLocalCollection())
 
-        // should be frozen since the operation type was unknown
+        // should be paused since the operation type was unknown
         ctx.queueConsumableRemoteUpdateEvent()
         ctx.doSyncPass()
         assertEquals(ctx.testDocument, ctx.findTestDocumentFromLocalCollection())
@@ -609,7 +609,7 @@ class DataSynchronizerUnitTests {
             ctx.findTestDocumentFromLocalCollection())
 
         // prepare a remote delete event, sync, and assert that nothing was affecting
-        // (since we're frozen)
+        // (since we're paused)
         ctx.queueConsumableRemoteDeleteEvent()
         ctx.doSyncPass()
         assertEquals(docAfterUpdate, ctx.findTestDocumentFromLocalCollection())
@@ -905,5 +905,43 @@ class DataSynchronizerUnitTests {
         ctx.verifyChangeEventListenerCalledForActiveDoc(1, ChangeEvent.changeEventForLocalInsert(
             ctx.namespace, ctx.testDocument, true))
         assertTrue(ctx.dataSynchronizer.isRunning)
+    }
+
+    @Test
+    fun testResumeSyncForDocument() {
+        val ctx = harness.freshTestContext()
+
+        // assert that resume returns false for a doc that doesn't exist yet
+        assertFalse(ctx.dataSynchronizer.resumeSyncForDocument(ctx.namespace, ctx.testDocumentId))
+
+        // insert and sync
+        ctx.insertTestDocument()
+        ctx.doSyncPass()
+
+        // throw and exception on the next sync pass, pausing the
+        // document config
+        ctx.exceptionToThrowDuringConflict = Exception("intentional")
+        ctx.queueConsumableRemoteUnknownEvent()
+        ctx.doSyncPass()
+
+        // assert that the doc is paused
+        assertTrue(
+            ctx.dataSynchronizer
+                .getSynchronizedDocuments(ctx.namespace)
+                .firstOrNull()?.isPaused ?: false)
+
+        // attempt a remote delete, which should fail
+        ctx.queueConsumableRemoteDeleteEvent()
+        ctx.doSyncPass()
+        assertEquals(ctx.testDocument, ctx.findTestDocumentFromLocalCollection())
+
+        // assert that resume returns true for our paused doc
+        assertTrue(ctx.dataSynchronizer.resumeSyncForDocument(ctx.namespace, ctx.testDocumentId))
+
+        // queue another remote delete, one that should work
+        // now that the document is no longer paused
+        ctx.queueConsumableRemoteDeleteEvent()
+        ctx.doSyncPass()
+        assertNull(ctx.findTestDocumentFromLocalCollection())
     }
 }

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
@@ -405,7 +405,8 @@ class SyncUnitTestHarness : Closeable {
 
         override fun queueConsumableRemoteUpdateEvent() {
             `when`(dataSynchronizer.getEventsForNamespace(any())).thenReturn(
-                mapOf(testDocument to ChangeEvent.changeEventForLocalUpdate(namespace, testDocumentId, null, testDocument, false)),
+                mapOf(testDocument to ChangeEvent.changeEventForLocalUpdate(
+                    namespace, testDocumentId, null, testDocument, false)),
                 mapOf())
         }
 

--- a/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/ProxySyncMethods.kt
+++ b/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/ProxySyncMethods.kt
@@ -92,4 +92,13 @@ interface ProxySyncMethods {
      * @return the result of the local or remote update.
      */
     fun deleteOneById(documentId: BsonValue): RemoteDeleteResult
+
+    /**
+     * A document that is paused no longer has remote updates applied to it.
+     * Any local updates to this document cause it to be thawed. An example of pausing a document
+     * is when a conflict is being resolved for that document and the handler throws an exception.
+     *
+     * @param documentId the id of the document to resume syncing
+     */
+    fun resumeSyncForDocument(documentId: BsonValue): Boolean
 }

--- a/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/ProxySyncMethods.kt
+++ b/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/ProxySyncMethods.kt
@@ -95,7 +95,7 @@ interface ProxySyncMethods {
 
     /**
      * A document that is paused no longer has remote updates applied to it.
-     * Any local updates to this document cause it to be thawed. An example of pausing a document
+     * Any local updates to this document cause it to be resumed. An example of pausing a document
      * is when a conflict is being resolved for that document and the handler throws an exception.
      *
      * @param documentId the id of the document to resume syncing

--- a/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/ProxySyncMethods.kt
+++ b/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/ProxySyncMethods.kt
@@ -94,6 +94,14 @@ interface ProxySyncMethods {
     fun deleteOneById(documentId: BsonValue): RemoteDeleteResult
 
     /**
+     * Return the set of synchronized document _ids in a namespace
+     * that have been paused due to an irrecoverable error.
+     *
+     * @return the set of paused document _ids in a namespace
+     */
+    fun getPausedDocumentIds(): Set<BsonValue>
+
+    /**
      * A document that is paused no longer has remote updates applied to it.
      * Any local updates to this document cause it to be resumed. An example of pausing a document
      * is when a conflict is being resolved for that document and the handler throws an exception.

--- a/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
+++ b/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
@@ -1390,6 +1390,7 @@ class SyncIntTestProxy(private val syncTestRunner: SyncIntTestRunner) {
             // freezing the document
             streamAndSync()
             Assert.assertTrue(errorEmitted)
+            assertEquals(result.insertedId, testSync.getPausedDocumentIds().first())
 
             // update the doc remotely
             val nextDoc = Document("hello", "friend")
@@ -1420,6 +1421,7 @@ class SyncIntTestProxy(private val syncTestRunner: SyncIntTestRunner) {
             // now that we're sync'd and resumed, it should be reflected locally
             streamAndSync()
 
+            assertTrue(testSync.getPausedDocumentIds().isEmpty())
             assertEquals(
                 withoutId(lastDoc),
                 withoutSyncVersion(

--- a/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
+++ b/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
@@ -871,7 +871,7 @@ class SyncIntTestProxy(private val syncTestRunner: SyncIntTestRunner) {
     }
 
     @Test
-    fun testFrozenDocumentConfig() {
+    fun testPausedDocumentConfig() {
         testSyncInBothDirections {
             val testSync = syncTestRunner.syncMethods()
             val remoteColl = syncTestRunner.remoteMethods()
@@ -924,7 +924,7 @@ class SyncIntTestProxy(private val syncTestRunner: SyncIntTestRunner) {
             sem.acquire()
             streamAndSync()
 
-            // it should not have updated the local doc, as the local doc should be frozen
+            // it should not have updated the local doc, as the local doc should be paused
             assertEquals(
                 withoutId(expectedDoc),
                 withoutSyncVersion(withoutId(testSync.find(Document("_id", result.insertedId)).first()!!)))
@@ -949,7 +949,7 @@ class SyncIntTestProxy(private val syncTestRunner: SyncIntTestRunner) {
             )
             sem.acquire()
 
-            // now that we're sync'd and unfrozen, it should be reflected locally
+            // now that we're sync'd and resumed, it should be reflected locally
             // TODO: STITCH-1958 Possible race condition here for update listening
             streamAndSync()
 
@@ -1342,6 +1342,88 @@ class SyncIntTestProxy(private val syncTestRunner: SyncIntTestRunner) {
             assertEquals(docAfterUpdate, withoutId(withoutSyncVersion(coll.findOneById(doc1Id)!!)))
             assertEquals(docAfterUpdate, withoutId(withoutSyncVersion(remoteColl.find(doc1Filter).first()!!)))
             assertTrue(eventSemaphore.tryAcquire(10, TimeUnit.SECONDS))
+        }
+    }
+
+    @Test
+    fun testResumeSyncForDocumentResumesSync() {
+        testSyncInBothDirections {
+            val testSync = syncTestRunner.syncMethods()
+            val remoteColl = syncTestRunner.remoteMethods()
+            var errorEmitted = false
+
+            var conflictCounter = 0
+
+            testSync.configure(
+                ConflictHandler { _: BsonValue, _: ChangeEvent<Document>, remoteEvent: ChangeEvent<Document> ->
+                    if (conflictCounter == 0) {
+                        conflictCounter++
+                        errorEmitted = true
+                        throw Exception("ouch")
+                    }
+                    remoteEvent.fullDocument
+                },
+                ChangeEventListener { _: BsonValue, _: ChangeEvent<Document> ->
+                },
+                ErrorListener { _, _ ->
+                })
+
+            // insert an initial doc
+            val testDoc = Document("hello", "world")
+            val result = testSync.insertOneAndSync(testDoc)
+
+            // do a sync pass, synchronizing the doc
+            streamAndSync()
+
+            Assert.assertNotNull(remoteColl.find(Document("_id", testDoc["_id"])).first())
+
+            // update the doc
+            val expectedDoc = Document("hello", "computer")
+            testSync.updateOneById(result.insertedId, Document("\$set", expectedDoc))
+
+            // create a conflict
+            var sem = watchForEvents(syncTestRunner.namespace)
+            remoteColl.updateOne(Document("_id", result.insertedId), withNewSyncVersionSet(Document("\$inc", Document("foo", 2))))
+            sem.acquire()
+
+            // do a sync pass, and throw an error during the conflict resolver
+            // freezing the document
+            streamAndSync()
+            Assert.assertTrue(errorEmitted)
+
+            // update the doc remotely
+            val nextDoc = Document("hello", "friend")
+
+            sem = watchForEvents(syncTestRunner.namespace)
+            remoteColl.updateOne(Document("_id", result.insertedId), nextDoc)
+            sem.acquire()
+            streamAndSync()
+
+            // it should not have updated the local doc, as the local doc should be paused
+            assertEquals(
+                withoutId(expectedDoc),
+                withoutSyncVersion(withoutId(testSync.find(Document("_id", result.insertedId)).first()!!)))
+
+            // resume syncing here
+            assertTrue(testSync.resumeSyncForDocument(result.insertedId))
+
+            // update the doc remotely
+            val lastDoc = Document("good night", "computer")
+
+            sem = watchForEvents(syncTestRunner.namespace)
+            remoteColl.updateOne(
+                Document("_id", result.insertedId),
+                withNewSyncVersion(lastDoc)
+            )
+            sem.acquire()
+
+            // now that we're sync'd and resumed, it should be reflected locally
+            streamAndSync()
+
+            assertEquals(
+                withoutId(lastDoc),
+                withoutSyncVersion(
+                    withoutId(testSync.find(Document("_id", result.insertedId)).first()!!)))
         }
     }
 

--- a/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestRunner.kt
+++ b/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestRunner.kt
@@ -135,4 +135,7 @@ interface SyncIntTestRunner {
 
     @Test
     fun testShouldUpdateUsingUpdateDescription()
+
+    @Test
+    fun testResumeSyncForDocumentResumesSync()
 }

--- a/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestRunner.kt
+++ b/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestRunner.kt
@@ -113,7 +113,7 @@ interface SyncIntTestRunner {
     fun testInsertInsertConflict()
 
     @Test
-    fun testFrozenDocumentConfig()
+    fun testPausedDocumentConfig()
 
     @Test
     fun testConfigure()

--- a/server/services/mongodb-remote/src/main/java/com/mongodb/stitch/server/services/mongodb/remote/Sync.java
+++ b/server/services/mongodb-remote/src/main/java/com/mongodb/stitch/server/services/mongodb/remote/Sync.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.stitch.server.services.mongodb.remote;
 
+import com.mongodb.MongoNamespace;
 import com.mongodb.stitch.core.services.mongodb.remote.RemoteDeleteResult;
 import com.mongodb.stitch.core.services.mongodb.remote.RemoteInsertOneResult;
 import com.mongodb.stitch.core.services.mongodb.remote.RemoteUpdateResult;
@@ -82,6 +83,15 @@ public interface Sync<DocumentT> {
    * @return the set of synchronized document ids in a namespace.
    */
   Set<BsonValue> getSyncedIds();
+
+  /**
+   * Unfreeze a document.
+   *
+   * @param documentId the id of the document to unfreeze
+   * @return true if successfully unfrozen, false if the document
+   *         could not be found or there was an error unfreezing
+   */
+  boolean unfreezeDocument(final BsonValue documentId);
 
   /**
    * Finds all documents in the collection.

--- a/server/services/mongodb-remote/src/main/java/com/mongodb/stitch/server/services/mongodb/remote/Sync.java
+++ b/server/services/mongodb-remote/src/main/java/com/mongodb/stitch/server/services/mongodb/remote/Sync.java
@@ -84,6 +84,14 @@ public interface Sync<DocumentT> {
   Set<BsonValue> getSyncedIds();
 
   /**
+   * Return the set of synchronized document _ids in a namespace
+   * that have been paused due to an irrecoverable error.
+   *
+   * @return the set of paused document _ids in a namespace
+   */
+  Set<BsonValue> getPausedDocumentIds();
+
+  /**
    * A document that is paused no longer has remote updates applied to it.
    * Any local updates to this document cause it to be resumed. An example of pausing a document
    * is when a conflict is being resolved for that document and the handler throws an exception.

--- a/server/services/mongodb-remote/src/main/java/com/mongodb/stitch/server/services/mongodb/remote/Sync.java
+++ b/server/services/mongodb-remote/src/main/java/com/mongodb/stitch/server/services/mongodb/remote/Sync.java
@@ -16,7 +16,6 @@
 
 package com.mongodb.stitch.server.services.mongodb.remote;
 
-import com.mongodb.MongoNamespace;
 import com.mongodb.stitch.core.services.mongodb.remote.RemoteDeleteResult;
 import com.mongodb.stitch.core.services.mongodb.remote.RemoteInsertOneResult;
 import com.mongodb.stitch.core.services.mongodb.remote.RemoteUpdateResult;
@@ -85,13 +84,15 @@ public interface Sync<DocumentT> {
   Set<BsonValue> getSyncedIds();
 
   /**
-   * Unfreeze a document.
+   * A document that is paused no longer has remote updates applied to it.
+   * Any local updates to this document cause it to be resumed. An example of pausing a document
+   * is when a conflict is being resolved for that document and the handler throws an exception.
    *
-   * @param documentId the id of the document to unfreeze
-   * @return true if successfully unfrozen, false if the document
-   *         could not be found or there was an error unfreezing
+   * @param documentId the id of the document to resume syncing
+   * @return true if successfully resumed, false if the document
+   *         could not be found or there was an error resuming
    */
-  boolean unfreezeDocument(final BsonValue documentId);
+  boolean resumeSyncForDocument(@Nonnull final BsonValue documentId);
 
   /**
    * Finds all documents in the collection.

--- a/server/services/mongodb-remote/src/main/java/com/mongodb/stitch/server/services/mongodb/remote/internal/SyncImpl.java
+++ b/server/services/mongodb-remote/src/main/java/com/mongodb/stitch/server/services/mongodb/remote/internal/SyncImpl.java
@@ -77,6 +77,11 @@ public class SyncImpl<DocumentT> implements Sync<DocumentT> {
   }
 
   @Override
+  public boolean unfreezeDocument(BsonValue documentId) {
+    return this.proxy.unfreezeDocument(documentId);
+  }
+
+  @Override
   public SyncFindIterable<DocumentT> find() {
     return new SyncFindIterableImpl<>(proxy.find());
   }

--- a/server/services/mongodb-remote/src/main/java/com/mongodb/stitch/server/services/mongodb/remote/internal/SyncImpl.java
+++ b/server/services/mongodb-remote/src/main/java/com/mongodb/stitch/server/services/mongodb/remote/internal/SyncImpl.java
@@ -77,8 +77,8 @@ public class SyncImpl<DocumentT> implements Sync<DocumentT> {
   }
 
   @Override
-  public boolean unfreezeDocument(BsonValue documentId) {
-    return this.proxy.unfreezeDocument(documentId);
+  public boolean resumeSyncForDocument(@Nonnull final BsonValue documentId) {
+    return this.proxy.resumeSyncForDocument(documentId);
   }
 
   @Override

--- a/server/services/mongodb-remote/src/main/java/com/mongodb/stitch/server/services/mongodb/remote/internal/SyncImpl.java
+++ b/server/services/mongodb-remote/src/main/java/com/mongodb/stitch/server/services/mongodb/remote/internal/SyncImpl.java
@@ -77,6 +77,11 @@ public class SyncImpl<DocumentT> implements Sync<DocumentT> {
   }
 
   @Override
+  public Set<BsonValue> getPausedDocumentIds() {
+    return this.proxy.getPausedDocumentIds();
+  }
+
+  @Override
   public boolean resumeSyncForDocument(@Nonnull final BsonValue documentId) {
     return this.proxy.resumeSyncForDocument(documentId);
   }

--- a/server/services/mongodb-remote/src/test/java/com/mongodb/stitch/server/services/mongodb/remote/internal/SyncMongoClientIntTests.kt
+++ b/server/services/mongodb-remote/src/test/java/com/mongodb/stitch/server/services/mongodb/remote/internal/SyncMongoClientIntTests.kt
@@ -96,6 +96,10 @@ class SyncMongoClientIntTests : BaseStitchServerIntTest(), SyncIntTestRunner {
         override fun find(filter: Bson): Iterable<Document?> {
             return sync.find(filter)
         }
+
+        override fun resumeSyncForDocument(documentId: BsonValue): Boolean {
+            return sync.resumeSyncForDocument(documentId)
+        }
     }
 
     private val mongodbUriProp = "test.stitch.mongodbURI"
@@ -270,7 +274,7 @@ class SyncMongoClientIntTests : BaseStitchServerIntTest(), SyncIntTestRunner {
 
     @Test
     override fun testFrozenDocumentConfig() {
-        testProxy.testFrozenDocumentConfig()
+        testProxy.testPausedDocumentConfig()
     }
 
     @Test
@@ -306,6 +310,11 @@ class SyncMongoClientIntTests : BaseStitchServerIntTest(), SyncIntTestRunner {
     @Test
     override fun testShouldUpdateUsingUpdateDescription() {
         testProxy.testShouldUpdateUsingUpdateDescription()
+    }
+
+    @Test
+    override fun testResumeSyncForDocumentResumesSync() {
+        testProxy.testResumeSyncForDocumentResumesSync()
     }
 
     /**

--- a/server/services/mongodb-remote/src/test/java/com/mongodb/stitch/server/services/mongodb/remote/internal/SyncMongoClientIntTests.kt
+++ b/server/services/mongodb-remote/src/test/java/com/mongodb/stitch/server/services/mongodb/remote/internal/SyncMongoClientIntTests.kt
@@ -273,7 +273,7 @@ class SyncMongoClientIntTests : BaseStitchServerIntTest(), SyncIntTestRunner {
     }
 
     @Test
-    override fun testFrozenDocumentConfig() {
+    override fun testPausedDocumentConfig() {
         testProxy.testPausedDocumentConfig()
     }
 

--- a/server/services/mongodb-remote/src/test/java/com/mongodb/stitch/server/services/mongodb/remote/internal/SyncMongoClientIntTests.kt
+++ b/server/services/mongodb-remote/src/test/java/com/mongodb/stitch/server/services/mongodb/remote/internal/SyncMongoClientIntTests.kt
@@ -100,6 +100,10 @@ class SyncMongoClientIntTests : BaseStitchServerIntTest(), SyncIntTestRunner {
         override fun resumeSyncForDocument(documentId: BsonValue): Boolean {
             return sync.resumeSyncForDocument(documentId)
         }
+
+        override fun getPausedDocumentIds(): Set<BsonValue> {
+            return sync.pausedDocumentIds
+        }
     }
 
     private val mongodbUriProp = "test.stitch.mongodbURI"


### PR DESCRIPTION
The main addition of this ticket is the added method `resumeSyncForDocument`. A major secondary change is that the language for "frozen/thawed" has been switched to "paused/resumed". This is the documentation for this method:

```
/**
   * A document that is paused no longer has remote updates applied to it.
   * Any local updates to this document cause it to be resumed. An example of pausing a document
   * is when a conflict is being resolved for that document and the handler throws an exception.
   *
   * @param documentId the id of the document to resume syncing
   * @return true if successfully resumed, false if the document
   *         could not be found or there was an error resuming
*/
boolean resumeSyncForDocument(@Nonnull final BsonValue documentId);
```

This method is proxied upwards from `DataSynchronizer` => `CoreSync` => `Sync`.

The tests assert that, in the event of an irrecoverable error, a document is paused, and that document can be resumed via this method. The method should return the appropriate boolean value if the resume was successful. Operations should then be able to be sync'd on said document.