### PR TITLE
STITCH-2185 Fix various issues with sync recovery logic, and add unit tests

### DIFF
--- a/core/sdk/src/main/java/com/mongodb/stitch/core/auth/StitchUserProfile.java
+++ b/core/sdk/src/main/java/com/mongodb/stitch/core/auth/StitchUserProfile.java
@@ -86,7 +86,7 @@ public interface StitchUserProfile {
    * @return the minmum age of the user.
    */
   @Nullable
-  Integer getMinAge();
+  String getMinAge();
 
   /**
    * Returns the maximum age of the user.
@@ -94,5 +94,5 @@ public interface StitchUserProfile {
    * @return the maximum age of the user.
    */
   @Nullable
-  Integer getMaxAge();
+  String getMaxAge();
 }

--- a/core/sdk/src/main/java/com/mongodb/stitch/core/auth/internal/StitchUserProfileImpl.java
+++ b/core/sdk/src/main/java/com/mongodb/stitch/core/auth/internal/StitchUserProfileImpl.java
@@ -92,23 +92,15 @@ public class StitchUserProfileImpl implements StitchUserProfile {
   /**
    * Get the minimum age of this user; may be null.
    */
-  public Integer getMinAge() {
-    final String age = data.get(DataFields.MIN_AGE);
-    if (age == null) {
-      return null;
-    }
-    return Integer.parseInt(age);
+  public String getMinAge() {
+    return data.get(DataFields.MIN_AGE);
   }
 
   /**
    * Get the maximum age of this user; may be null.
    */
-  public Integer getMaxAge() {
-    final String age = data.get(DataFields.MAX_AGE);
-    if (age == null) {
-      return null;
-    }
-    return Integer.parseInt(age);
+  public String getMaxAge() {
+    return data.get(DataFields.MAX_AGE);
   }
 
   public List<? extends StitchUserIdentity> getIdentities() {

--- a/core/sdk/src/test/java/com/mongodb/stitch/core/auth/StitchUserProfileUnitTests.java
+++ b/core/sdk/src/test/java/com/mongodb/stitch/core/auth/StitchUserProfileUnitTests.java
@@ -63,8 +63,8 @@ public class StitchUserProfileUnitTests {
     assertEquals(stitchUserProfileImpl.getGender(), gender);
     assertEquals(stitchUserProfileImpl.getBirthday(), birthday);
     assertEquals(stitchUserProfileImpl.getPictureUrl(), pictureUrl);
-    assertEquals(stitchUserProfileImpl.getMinAge(), Integer.valueOf(minAge));
-    assertEquals(stitchUserProfileImpl.getMaxAge(), Integer.valueOf(maxAge));
+    assertEquals(stitchUserProfileImpl.getMinAge(), minAge);
+    assertEquals(stitchUserProfileImpl.getMaxAge(), maxAge);
     assertEquals(stitchUserProfileImpl.getUserType(), UserType.NORMAL);
     assertEquals(stitchUserProfileImpl.getIdentities().size(), 1);
     assertEquals(stitchUserProfileImpl.getIdentities().get(0), anonIdentity);

--- a/core/sdk/src/test/java/com/mongodb/stitch/core/auth/internal/model/StoreAuthInfoUnitTests.java
+++ b/core/sdk/src/test/java/com/mongodb/stitch/core/auth/internal/model/StoreAuthInfoUnitTests.java
@@ -85,8 +85,8 @@ public class StoreAuthInfoUnitTests {
     final Document dataDoc = (Document) userProfileDoc.get("data");
     assertEquals(dataDoc.get("first_name"), mockProfile.getFirstName());
     assertEquals(dataDoc.get("last_name"), mockProfile.getLastName());
-    assertEquals(Integer.valueOf((String) dataDoc.get("min_age")), mockProfile.getMinAge());
-    assertEquals(Integer.valueOf((String) dataDoc.get("max_age")), mockProfile.getMaxAge());
+    assertEquals(dataDoc.get("min_age"), mockProfile.getMinAge());
+    assertEquals(dataDoc.get("max_age"), mockProfile.getMaxAge());
     assertEquals(dataDoc.get("birthday"), mockProfile.getBirthday());
     assertEquals(dataDoc.get("gender"), mockProfile.getGender());
     assertEquals(dataDoc.get("picture"), mockProfile.getPictureUrl());

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
@@ -256,6 +256,9 @@ public class DataSynchronizer implements NetworkMonitor.StateListener {
               localCollection.deleteOne(filter);
               break;
             case UNKNOWN:
+              throw new IllegalStateException(
+                      "there should not be a pending write with an unknown event type"
+              );
               // TODO(question for review): should I throw IllegalStateException here? There should
               // never be pending writes with an unknown event type, but if someone was messing
               // with the config collection we might want to stop the synchronizer to prevent

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
@@ -2377,7 +2377,7 @@ public class DataSynchronizer implements NetworkMonitor.StateListener {
             == ChangeEvent.OperationType.INSERT) {
           desyncDocumentFromRemote(config.getNamespace(), config.getDocumentId());
           undoCollection.deleteOne(getDocumentIdFilter(documentId));
-          return result;
+          continue;
         }
 
         config.setSomePendingWrites(
@@ -2469,7 +2469,7 @@ public class DataSynchronizer implements NetworkMonitor.StateListener {
       undoCollection.insertOne(documentToDelete);
       localCollection.deleteOne(getDocumentIdFilter(documentId));
       desyncDocumentFromRemote(namespace, documentId);
-      undoCollection.deleteOne(getDocumentIdFilter(documentToDelete));
+      undoCollection.deleteOne(getDocumentIdFilter(documentId));
     } finally {
       lock.unlock();
     }

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
@@ -235,11 +235,11 @@ public class DataSynchronizer implements NetworkMonitor.StateListener {
     // operation, but in that case, the findOneAndReplace or delete is a no-op since restoring
     // the document to the state of the change event would be the same as recovering the undo
     // document.
-    for (CoreDocumentSynchronizationConfig docConfig : nsConfig.getSynchronizedDocuments()) {
+    for (final CoreDocumentSynchronizationConfig docConfig : nsConfig.getSynchronizedDocuments()) {
       final BsonValue documentId = docConfig.getDocumentId();
       final BsonDocument filter = getDocumentIdFilter(documentId);
 
-      if(recoveredIds.contains(docConfig.getDocumentId())) {
+      if (recoveredIds.contains(docConfig.getDocumentId())) {
         final ChangeEvent<BsonDocument> pendingWrite = docConfig.getLastUncommittedChangeEvent();
         if (pendingWrite != null) {
           switch (pendingWrite.getOperationType()) {
@@ -255,14 +255,14 @@ public class DataSynchronizer implements NetworkMonitor.StateListener {
             case DELETE:
               localCollection.deleteOne(filter);
               break;
-            case UNKNOWN:
-              throw new IllegalStateException(
-                      "there should not be a pending write with an unknown event type"
-              );
+            default:
               // TODO(question for review): should I throw IllegalStateException here? There should
               // never be pending writes with an unknown event type, but if someone was messing
               // with the config collection we might want to stop the synchronizer to prevent
               // further data corruption.
+              throw new IllegalStateException(
+                      "there should not be a pending write with an unknown event type"
+              );
           }
         }
       }
@@ -273,7 +273,7 @@ public class DataSynchronizer implements NetworkMonitor.StateListener {
     // these deletes or while carrying out the deletes, but after recovering the documents to
     // their desired state, that's okay because the next recovery pass will be effectively a no-op
     // up to this point.
-    for (BsonValue recoveredId : recoveredIds) {
+    for (final BsonValue recoveredId : recoveredIds) {
       undoCollection.deleteOne(getDocumentIdFilter(recoveredId));
     }
 

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
@@ -256,9 +256,8 @@ public class DataSynchronizer implements NetworkMonitor.StateListener {
               localCollection.deleteOne(filter);
               break;
             default:
-              // TODO(question for review): should I throw IllegalStateException here? There should
-              // never be pending writes with an unknown event type, but if someone was messing
-              // with the config collection we might want to stop the synchronizer to prevent
+              // There should never be pending writes with an unknown event type, but if someone
+              // is messing with the config collection we want to stop the synchronizer to prevent
               // further data corruption.
               throw new IllegalStateException(
                       "there should not be a pending write with an unknown event type"

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
@@ -205,7 +205,9 @@ public class DataSynchronizer implements NetworkMonitor.StateListener {
 
   /**
    * Recovers the state of synchronization for a namespace in case a system failure happened.
-   * The goal is to revert the namespace to a known, good state.
+   * The goal is to revert the namespace to a known, good state. This method itself is resilient
+   * to failures, since it doesn't delete any documents from the undo collection until the
+   * collection is in the desired state with respect to those documents.
    */
   private void recoverNamespace(final NamespaceSynchronizationConfig nsConfig) {
     final MongoCollection<BsonDocument> undoCollection =
@@ -214,6 +216,7 @@ public class DataSynchronizer implements NetworkMonitor.StateListener {
         getLocalCollection(nsConfig.getNamespace());
     final List<BsonDocument> undoDocs =
         undoCollection.find().into(new ArrayList<>());
+    final Set<BsonValue> recoveredIds = new HashSet<>();
 
     // Replace local docs with undo docs. Presence of an undo doc implies we had a system failure
     // during a write. This covers updates and deletes.
@@ -222,11 +225,59 @@ public class DataSynchronizer implements NetworkMonitor.StateListener {
       final BsonDocument filter = getDocumentIdFilter(documentId);
       localCollection.findOneAndReplace(
           filter, undoDoc, new FindOneAndReplaceOptions().upsert(true));
-      undoCollection.deleteOne(filter);
+      recoveredIds.add(documentId);
+    }
+
+    // If we recovered a document, but its pending writes are set to do something else, then the
+    // failure occurred after the pending writes were set, but before the undo document was
+    // deleted. In this case, we should restore the document to the state that the pending
+    // write indicates. There is a possibility that the pending write is from before the failed
+    // operation, but in that case, the findOneAndReplace or delete is a no-op since restoring
+    // the document to the state of the change event would be the same as recovering the undo
+    // document.
+    for (CoreDocumentSynchronizationConfig docConfig : nsConfig.getSynchronizedDocuments()) {
+      final BsonValue documentId = docConfig.getDocumentId();
+      final BsonDocument filter = getDocumentIdFilter(documentId);
+
+      if(recoveredIds.contains(docConfig.getDocumentId())) {
+        final ChangeEvent<BsonDocument> pendingWrite = docConfig.getLastUncommittedChangeEvent();
+        if (pendingWrite != null) {
+          switch (pendingWrite.getOperationType()) {
+            case INSERT:
+            case UPDATE:
+            case REPLACE:
+              localCollection.findOneAndReplace(
+                      filter,
+                      pendingWrite.getFullDocument(),
+                      new FindOneAndReplaceOptions().upsert(true)
+              );
+              break;
+            case DELETE:
+              localCollection.deleteOne(filter);
+              break;
+            case UNKNOWN:
+              // TODO(question for review): should I throw IllegalStateException here? There should
+              // never be pending writes with an unknown event type, but if someone was messing
+              // with the config collection we might want to stop the synchronizer to prevent
+              // further data corruption.
+          }
+        }
+      }
+    }
+
+    // Delete all of our undo documents. If we've reached this point, we've recovered the local
+    // collection to the state we want with respect to all of our undo documents. If we fail before
+    // these deletes or while carrying out the deletes, but after recovering the documents to
+    // their desired state, that's okay because the next recovery pass will be effectively a no-op
+    // up to this point.
+    for (BsonValue recoveredId : recoveredIds) {
+      undoCollection.deleteOne(getDocumentIdFilter(recoveredId));
     }
 
     // Find local documents for which there are no document configs and delete them. This covers
-    // inserts, upserts, and desync deletes.
+    // inserts, upserts, and desync deletes. This will occur on any recovery pass regardless of
+    // the documents in the undo collection, so it's fine that we do this after deleting the undo
+    // documents.
     localCollection.deleteMany(new BsonDocument(
         "_id",
         new BsonDocument(

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerTestContext.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerTestContext.kt
@@ -2,6 +2,7 @@ package com.mongodb.stitch.core.services.mongodb.remote.sync.internal
 
 import com.mongodb.MongoNamespace
 import com.mongodb.client.MongoClient
+import com.mongodb.client.MongoCollection
 import com.mongodb.client.result.DeleteResult
 import com.mongodb.client.result.UpdateResult
 import com.mongodb.stitch.core.internal.net.Event
@@ -94,6 +95,16 @@ interface DataSynchronizerTestContext : Closeable {
      * Reconfigure dataSynchronizer. Do a sync pass.
      */
     fun doSyncPass()
+
+    /**
+     * Returns an instance of the local synchronized collection.
+     */
+    fun getLocalCollection(): MongoCollection<BsonDocument>
+
+    /**
+     * Sets the pending writes for a particular synchronized document ID.
+     */
+    fun setPendingWritesForDocId(documentId: BsonValue, event: ChangeEvent<BsonDocument>)
 
     /**
      * Attempt to find the contextual test document locally.

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerTestContext.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerTestContext.kt
@@ -133,6 +133,11 @@ interface DataSynchronizerTestContext : Closeable {
     fun verifyStopCalled(times: Int)
 
     /**
+     * Verify that the undo collection of the data synchronizer is empty.
+     */
+    fun verifyUndoCollectionEmpty()
+
+    /**
      * Queue a pseudo-remote insert event to be consumed during R2L.
      */
     fun queueConsumableRemoteInsertEvent()

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerTestContext.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerTestContext.kt
@@ -61,6 +61,11 @@ interface DataSynchronizerTestContext : Closeable {
     val dataSynchronizer: DataSynchronizer
 
     /**
+     * An instance of the local synchronized collection.
+     */
+    val localCollection: MongoCollection<BsonDocument>
+
+    /**
      * Reconfigure the dataSynchronizer.
      */
     fun reconfigure()
@@ -95,11 +100,6 @@ interface DataSynchronizerTestContext : Closeable {
      * Reconfigure dataSynchronizer. Do a sync pass.
      */
     fun doSyncPass()
-
-    /**
-     * Returns an instance of the local synchronized collection.
-     */
-    fun getLocalCollection(): MongoCollection<BsonDocument>
 
     /**
      * Sets the pending writes for a particular synchronized document ID.

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerTestContext.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerTestContext.kt
@@ -30,6 +30,8 @@ enum class TestVersionState {
  */
 interface DataSynchronizerTestContext : Closeable {
     val namespace: MongoNamespace
+    val clientKey: String
+    val instanceKey: String
     val testDocument: BsonDocument
     val testDocumentId: BsonValue
     val testDocumentFilter: BsonDocument

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerUnitTests.kt
@@ -10,9 +10,14 @@ import com.mongodb.stitch.core.services.mongodb.remote.internal.CoreRemoteFindIt
 import com.mongodb.stitch.core.services.mongodb.remote.internal.CoreRemoteFindIterableImpl
 import com.mongodb.stitch.core.services.mongodb.remote.sync.internal.SyncUnitTestHarness.Companion.withoutSyncVersion
 import com.mongodb.stitch.server.services.mongodb.local.internal.ServerEmbeddedMongoClientFactory
-import org.bson.*
+import org.bson.BsonBoolean
+import org.bson.BsonDocument
+import org.bson.BsonInt32
+import org.bson.BsonObjectId
+import org.bson.BsonString
 import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.configuration.CodecRegistries
+import org.bson.Document
 import org.junit.After
 
 import org.junit.Assert.assertEquals
@@ -29,7 +34,7 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import java.lang.Exception
-import java.util.*
+import java.util.Collections
 
 class DataSynchronizerUnitTests {
     companion object {

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerUnitTests.kt
@@ -1302,7 +1302,6 @@ class DataSynchronizerUnitTests {
         // queue another remote delete, one that should work
         // now that the document is no longer paused
         ctx.queueConsumableRemoteDeleteEvent()
-
         ctx.doSyncPass()
         assertNull(ctx.findTestDocumentFromLocalCollection())
     }
@@ -1617,7 +1616,7 @@ class DataSynchronizerUnitTests {
         origCtx.dataSynchronizer.stop()
 
         // simulate a failure case where an update started, but did not get pending writes set
-        origCtx.getLocalCollection()
+        origCtx.localCollection
                 .updateOne(
                         BsonDocument("_id", testDocumentId),
                         BsonDocument("\$set", BsonDocument("oops", BsonBoolean(true)))
@@ -1652,7 +1651,7 @@ class DataSynchronizerUnitTests {
 
         // simulate a failure case where an update started and got pending writes set, but the undo
         // document still exists
-        origCtx.getLocalCollection()
+        origCtx.localCollection
                 .updateOne(
                         BsonDocument("_id", testDocumentId),
                         BsonDocument("\$set", BsonDocument("oops", BsonBoolean(true)))
@@ -1698,7 +1697,7 @@ class DataSynchronizerUnitTests {
         origCtx.dataSynchronizer.stop()
 
         // simulate a failure case where a delete started, but did not get pending writes set
-        origCtx.getLocalCollection()
+        origCtx.localCollection
                 .deleteOne(
                         BsonDocument("_id", testDocumentId)
                 )
@@ -1732,7 +1731,7 @@ class DataSynchronizerUnitTests {
 
         // simulate a failure case where a delete started and got pending writes, but the undo
         // document still exists
-        origCtx.getLocalCollection()
+        origCtx.localCollection
                 .deleteOne(
                         BsonDocument("_id", testDocumentId)
                 )
@@ -1779,7 +1778,7 @@ class DataSynchronizerUnitTests {
 
         expectedTestDocument["count"] = BsonInt32(2)
 
-        origCtx.getLocalCollection()
+        origCtx.localCollection
                 .updateOne(
                         BsonDocument("_id", testDocumentId),
                         BsonDocument("\$set", BsonDocument("oops", BsonBoolean(true)))
@@ -1812,7 +1811,7 @@ class DataSynchronizerUnitTests {
 
         origCtx.dataSynchronizer.stop()
 
-        origCtx.getLocalCollection()
+        origCtx.localCollection
                 .updateOne(
                         BsonDocument("_id", testDocumentId),
                         BsonDocument("\$set", BsonDocument("oops", BsonBoolean(true)))

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
@@ -223,11 +223,11 @@ class SyncUnitTestHarness : Closeable {
 
     @Suppress("UNCHECKED_CAST")
     private class DataSynchronizerTestContextImpl(
-            shouldPreconfigure: Boolean = true,
-            undoDocuments: List<BsonDocument> = ArrayList(),
-            override val namespace: MongoNamespace = newNamespace(),
-            override val clientKey: String = ObjectId().toHexString(),
-            override val instanceKey: String = "${Random().nextInt()}"
+        shouldPreconfigure: Boolean = true,
+        undoDocuments: List<BsonDocument> = ArrayList(),
+        override val namespace: MongoNamespace = newNamespace(),
+        override val clientKey: String = ObjectId().toHexString(),
+        override val instanceKey: String = "${Random().nextInt()}"
     ) : DataSynchronizerTestContext {
         open class TestChangeEventListener(
             private val expectedEvent: ChangeEvent<BsonDocument>?,
@@ -333,10 +333,6 @@ class SyncUnitTestHarness : Closeable {
                 }
             }
 
-            // Insert an unsynced document into the local collection, that we will later verify
-            // is removed by the recovery sequence.
-            insertUnsyncedDocumentIntoLocalCollection()
-
             Mockito.spy(DataSynchronizer(
                     instanceKey,
                     service,
@@ -425,13 +421,6 @@ class SyncUnitTestHarness : Closeable {
 
         private fun insertDocumentIntoUndoCollection(document: BsonDocument) {
             undoCollection.insertOne(document)
-        }
-
-        private fun insertUnsyncedDocumentIntoLocalCollection() {
-            localClient
-                    .getDatabase(namespace.databaseName)
-                    .getCollection(namespace.collectionName, BsonDocument::class.java)
-                    .insertOne(BsonDocument("this",  BsonString("is garbage")))
         }
 
         override fun updateTestDocument(): UpdateResult {
@@ -712,8 +701,8 @@ class SyncUnitTestHarness : Closeable {
     }
 
     internal fun testContextFromExistingContext(
-            existingCtx: DataSynchronizerTestContext,
-            undoDocuments: List<BsonDocument> = ArrayList()
+        existingCtx: DataSynchronizerTestContext,
+        undoDocuments: List<BsonDocument> = ArrayList()
     ): DataSynchronizerTestContext {
         // don't close the underlying synchronizer yet since that would release the local client
         // needed for the next test context. We will close this data synchronizer when we make a

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
@@ -715,7 +715,6 @@ class SyncUnitTestHarness : Closeable {
 
         // perform a no-op write so that we wait for the recovery pass to complete. This works
         // since the recovery routine write-locks all namespaces until recovery is done.
-        val synchronizer = latestCtx!!.dataSynchronizer
         latestCtx!!.dataSynchronizer.updateOne(
                 latestCtx!!.namespace,
                 BsonDocument("_id", BsonString("nonexistent")),


### PR DESCRIPTION
This PR supplements our sync unit tests with tests that do the following
* Verifies that undo documents are never leaked when write operations complete successfully.
* Verifies that several failure scenarios are recovered properly.
* Verifies that pathological inputs unrelated to synchronized documents are not stored in the local synchronized collection.

In writing these tests, I found various bugs in the recovery logic that should now be fixed. Some documents were getting leaked, and rollbacks sometimes occurred when they shouldn't have.

Also did a drive-by change to expose the min age and max age in a user profile to be Strings rather than ints. This follows the recent change to the iOS SDK, and protects the SDK from min_age and max_age String inputs that don't represent integer values.