### PR TITLE
Adding ProGuard rules to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,33 @@ implementation 'org.mongodb:stitch-android-services-mongodb-remote:4.1.4'
 implementation 'org.mongodb:stitch-android-services-twilio:4.1.4'
 ```
 
+#### R8 / ProGuard
+
+For Android applications with ProGuard and minify enabled, add the following rules to prevent ProGuard from renaming and removing classes and members:
+
+```
+# MongoDB and Stitch
+-keep class com.mongodb.client.model.** { *; }
+-keep class com.mongodb.stitch.core.auth.internal.models.** { *; }
+-keep class com.mongodb.stitch.core.internal.net.** { *; }
+-keep class com.mongodb.embedded.capi.internal.* { *; }
+-keep class com.mongodb.embedded.client.MongoEmbeddedSettings { *; }
+
+# Sun JNA Package
+-keep class com.sun.jna.** { *; }
+
+# Jackson
+-keep class com.fasterxml.jackson.databind.ObjectMapper {
+    public <methods>;
+    protected <methods>;
+}
+-keep class com.fasterxml.jackson.databind.ObjectWriter {
+    public ** writeValueAsString(**);
+}
+-keepnames class com.fasterxml.jackson.** { *; }
+-dontwarn com.fasterxml.jackson.databind.**
+```
+
 ### Server/Java
 
 Add the following to the build.gradle for your module:


### PR DESCRIPTION
## Problem

Currently the SDK silently fails if not configured to work with ProGuard.

## Solution

Having custom rules to be added in an applications proguard rules file. 

### What are the rules for: 

1. Keeps all classes and classes in subpackages as well subclass for the package `com.mongodb.client.model`. This is where there are `Filters` and `Updates` models. which should not be technically obfuscated. 
2. Keeps all classes and classes in subpackages as well subclass for the package `com.mongodb.stitch.core.auth.internal.models` and 
`com.mongodb.stitch.core.internal.net`. This contains request and response models
3. Keeps all classes and subclasses for the package `com.mongodb.embedded.capi.internal` This has the `CAPI` class which has JNI bindings. 
4. Keeps the class `com.mongodb.embedded.client.MongoEmbeddedSettings` 
5. Keeps all classes and classes in subpackages as well subclass for the package `com.sun.jna`. Used for native object access. 
6. Proguard rules for Jackson, used as the serialization nd deserialzation component in the sdk [Source](https://github.com/FasterXML/jackson-docs/wiki/JacksonOnAndroid)