### PR TITLE
DOCSP-3936 Push docs to docs.mongodb.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The official [MongoDB Stitch](https://stitch.mongodb.com/) SDK for Android/Java.
 - [Example Usage](#example-usage)
 
 ## Documentation
-* [API/Javadoc Documentation](https://s3.amazonaws.com/stitch-sdks/java/docs/4.1.4/index.html)
+* [API/Javadoc Documentation](https://docs.mongodb.com/stitch-sdks/java/4.1.4/index.html)
 * [MongoDB Stitch Documentation](https://docs.mongodb.com/stitch/)
 
 ## Discussion

--- a/contrib/bump_version.bash
+++ b/contrib/bump_version.bash
@@ -112,12 +112,12 @@ fi
 
 if [ -z "$NEW_VERSION_QUALIFIER" ]; then
 	# Publish to MAJOR, MAJOR.MINOR
-	aws s3 cp ./build/docs/javadoc s3://stitch-sdks/java/docs/$NEW_VERSION_MAJOR --recursive --acl public-read
-	aws s3 cp ./build/docs/javadoc s3://stitch-sdks/java/docs/$NEW_VERSION_MAJOR.$NEW_VERSION_MINOR --recursive --acl public-read
+	aws s3 cp ./build/docs/javadoc s3://stitch-sdks/stitch-sdks/java/$NEW_VERSION_MAJOR --recursive --acl public-read
+	aws s3 cp ./build/docs/javadoc s3://stitch-sdks/stitch-sdks/java/$NEW_VERSION_MAJOR.$NEW_VERSION_MINOR --recursive --acl public-read
 fi
 
 # Publish to full version
-aws s3 cp ./build/docs/javadoc s3://stitch-sdks/java/docs/$NEW_VERSION --recursive --acl public-read
+aws s3 cp ./build/docs/javadoc s3://stitch-sdks/stitch-sdks/java/$NEW_VERSION --recursive --acl public-read
 
 BRANCH_NAME=`git branch | grep -e "^*" | cut -d' ' -f 2`
-aws s3 cp ./build/docs/javadoc s3://stitch-sdks/java/docs/branch/$BRANCH_NAME --recursive --acl public-read
+aws s3 cp ./build/docs/javadoc s3://stitch-sdks/stitch-sdks/java/branch/$BRANCH_NAME --recursive --acl public-read


### PR DESCRIPTION
This updates the destination to a stitch-sdks subdirectory on the
existing bucket so that docs.mongodb.com/stitch-sdks can find it.
(Not sure, this was specifically required by techops.)

Removes the /docs/ part which is arguably redundant now that it is
hosted on docs.mongodb.com.

Also updates the README for the new docs URL. Please publish
the docs and check that the new URL works.