### PR TITLE
STITCH-2340 ProGuard integration and testing

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -332,6 +332,50 @@ tasks:
             ./gradlew connectedAndroidTest --info --continue --warning-mode=all --stacktrace  < /dev/null
       - func: "publish_coveralls"
 
+  - name: run_android_tests_with_proguard
+    exec_timeout_secs: 7200
+    commands:
+    - func: "fetch_go111"
+    - func: "fetch_source"
+    - func: "setup_mongod"
+    - func: "setup_android"
+    - func: "setup_stitch"
+    - func: "setup_emulator"
+    - func: "setup_test_creds"
+    - command: shell.exec
+      params:
+        shell: "bash"
+        background: true
+        script: |
+          set -e
+          LOGCAT_PID=''
+          cleanup() {
+              kill -9 $LOGCAT_PID
+          }
+          trap cleanup EXIT
+
+          SDK_HOME=`pwd`/.android
+          $SDK_HOME/platform-tools/adb logcat &
+          LOGCAT_PID=$!
+          sleep infinity
+    - command: shell.exec
+      params:
+        shell: "bash"
+        script: |
+          set -e
+          SDK_HOME=`pwd`/.android
+          export JAVA_HOME="/opt/java/jdk8"
+
+          export ANDROID_HOME=$SDK_HOME
+          export ANDROID_SDK_ROOT=$SDK_HOME
+          export ANDROID_SDK_HOME=$SDK_HOME
+          export ADB_INSTALL_TIMEOUT=30
+          cd stitch-java-sdk
+          echo "running android tests"
+          echo "test.stitch.baseURL=http://10.0.2.2:9090" >> local.properties
+          ./gradlew connectedAndroidTest -PwithProguardMinification --info --continue --warning-mode=all --stacktrace  < /dev/null
+    - func: "publish_coveralls"
+
   - name: finalize_coverage
     depends_on:
       - name: run_core_tests
@@ -340,6 +384,7 @@ tasks:
       - name: run_android_tests
         variant: "rhel70"
         status: '*'
+      - name: run_android_tests_with_proguard
     commands:
       - command: shell.exec
         params:
@@ -410,5 +455,6 @@ buildvariants:
   tasks:
     - name: run_core_tests
     - name: run_android_tests
+    - name: run_android_tests_with_proguard
     - name: lint
     - name: finalize_coverage

--- a/README.md
+++ b/README.md
@@ -54,30 +54,9 @@ implementation 'org.mongodb:stitch-android-services-twilio:4.1.4'
 
 #### R8 / ProGuard
 
-For Android applications with ProGuard and minify enabled, add the following rules to prevent ProGuard from renaming and removing classes and members:
+For Android applications with ProGuard and minify enabled, the Stitch SDK provides a consumer ProGuard rules file that will automatically be applied when including the SDK.
 
-```
-# MongoDB and Stitch
--keep class com.mongodb.client.model.** { *; }
--keep class com.mongodb.stitch.core.auth.internal.models.** { *; }
--keep class com.mongodb.stitch.core.internal.net.** { *; }
--keep class com.mongodb.embedded.capi.internal.* { *; }
--keep class com.mongodb.embedded.client.MongoEmbeddedSettings { *; }
-
-# Sun JNA Package
--keep class com.sun.jna.** { *; }
-
-# Jackson
--keep class com.fasterxml.jackson.databind.ObjectMapper {
-    public <methods>;
-    protected <methods>;
-}
--keep class com.fasterxml.jackson.databind.ObjectWriter {
-    public ** writeValueAsString(**);
-}
--keepnames class com.fasterxml.jackson.** { *; }
--dontwarn com.fasterxml.jackson.databind.**
-```
+If you experience any ProGuard related warnings or error when using the Stitch SDK with an application where minify is enabled, try manually adding the rules in [android/core/lib-proguard-rules.pro](android/core/lib-proguard-rules.pro) to your application's `proguard-rules.pro` file. If that doesn't work, please open an issue on this repository.
 
 ### Server/Java
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,6 +39,12 @@ subprojects {
                 }
                 buildTypes {
                     debug {
+                        if (project.hasProperty('withProguardMinification')) {
+                            minifyEnabled true
+                            testProguardFile getDefaultProguardFile('proguard-android.txt')
+                        } else {
+                            minifyEnabled false
+                        }
                         testCoverageEnabled true
                     }
                     release {

--- a/android/core/build.gradle
+++ b/android/core/build.gradle
@@ -19,6 +19,7 @@ android {
     defaultConfig {
         minSdkVersion min_api
         targetSdkVersion target_api
+        consumerProguardFiles 'lib-proguard-rules.pro'
     }
 }
 

--- a/android/core/lib-proguard-rules.pro
+++ b/android/core/lib-proguard-rules.pro
@@ -1,0 +1,43 @@
+# MongoDB and Stitch
+-keep class com.mongodb.client.model.** { *; }
+-keep class com.mongodb.embedded.capi.internal.* { *; }
+-keep class com.mongodb.embedded.client.MongoEmbeddedSettings { *; }
+-keep class com.mongodb.stitch.android.** { *; }
+-keep class com.mongodb.stitch.core.auth.internal.models.** { *; }
+-keep class com.mongodb.stitch.core.internal.net.** { *; }
+
+# Sun JNA Package
+-keep class com.sun.jna.** { *; }
+
+# Jackson
+-keep class com.fasterxml.jackson.databind.ObjectMapper {
+    public <methods>;
+    protected <methods>;
+}
+-keep class com.fasterxml.jackson.databind.ObjectWriter {
+    public ** writeValueAsString(**);
+}
+-keepnames class com.fasterxml.jackson.** { *; }
+-dontwarn com.fasterxml.jackson.databind.**
+
+# SLF4J Logger
+-keep class org.slf4j.** { *; }
+-dontwarn org.slf4j.**
+
+# OkHttp Dependencies
+-keep class org.codehaus.mojo.animal_sniffer.** { *; }
+-keep class org.conscrypt.** { *; }
+-dontwarn org.codehaus.mojo.animal_sniffer.**
+-dontwarn org.conscrypt.**
+
+# MongoDB Driver Features not required for Embedded MongoDB
+-dontwarn io.netty.** # Connecting to clusters over network
+-dontwarn java.awt.** # Abstract Window Toolkit
+-dontwarn java.lang.management.** # JMX Monitoring
+-dontwarn javax.naming.** # DNS resolution
+-dontwarn javax.management.** # JMX Monitoring
+-dontwarn javax.security.auth.callback.** # PLAIN auth
+-dontwarn javax.security.sasl.**
+-dontwarn jnr.unixsocket.**
+-dontwarn org.ietf.jgss.** # Kerberos
+-dontwarn org.xerial.snappy.** # Wire protocol compression


### PR DESCRIPTION
This PR may be small but it took a while to figure out the right incantations for all these things :)

This PR does the following
* Adds a new `lib-proguard-rules.pro` to `android.defaultConfig.consumerProguardFiles` in the `stitch-android-core` library. This adds the rules necessary for an Android app using the SDK to be minified with Proguard correctly.
    * Since it is a consumer ProGuard file, it means that any app APK or test APK that consumes this library (via our SDK for instance) and enables proguard minification will automatically apply these rules when running proguard. This does not run ProGuard on our SDK, since [libraries are not supposed to](https://stackoverflow.com/questions/10982344/is-proguard-cfg-needed-for-library-projects#10992604).
    * This only applies to Android. I did not do any work to create a consumer ProGuard file for the Server SDK. I figured it wasn’t in scope for this ticket, but I could open another ticket if we think it’s worthwhile.
* Updates the README to explain this new functionality.
* Updates the overall Android `android/build.gradle` in our `Stitch-SDK` project so that Android debug builds (i.e. our tests) will be minified with ProGuard if they’re executed with the flag `-PwithProguardMinification`
* Adds an evergreen task to run the Android tests with proguard minification enabled

To verify that I configured everything correctly:
* I manually verified that the `./gradlew connectedAndroidTest -PwithProguardMinification` fails if our consumer proguard file `stitch-android-core` is empty 
* I manually verified that the `./gradlew connectedAndroidTest -PwithProguardMinification` succeeds if our consumer proguard file `stitch-android-core` is configured correctly 
* I manually verified that the `./gradlew connectedAndroidTest` succeeds if our consumer proguard file `stitch-android-core` is empty
* I manually verified that the example apps work if minification is enabled. (they previously did not)

As for this last task in the ticket: “Update the build/release process to require the pre-release integration tests to be run before release will successfully execute”, I did not do this. From my understanding, we don’t actually have any custom pre-release hooks right now. I thought Evergreen has been our benchmark for whether or not we will release something. 

If I’m wrong then let me know where I can add the pre-release tasks, otherwise I think it might be out of scope for this ticket.