### PR TITLE
STITCH-2491 - Properly handle missing documents in DataSynchronizer

### DIFF
--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
@@ -569,10 +569,12 @@ public class DataSynchronizer implements NetworkMonitor.StateListener {
         for (final BsonValue unseenId : unseenIds) {
           final CoreDocumentSynchronizationConfig docConfig =
               nsConfig.getSynchronizedDocument(unseenId);
-          if (docConfig == null
-              || docConfig.getLastKnownRemoteVersion() == null
-              || docConfig.isPaused()) {
+          if (docConfig == null) {
             // means we aren't actually synchronizing on this remote doc
+            continue;
+          }
+          if (docConfig.getLastKnownRemoteVersion() == null || docConfig.isPaused()) {
+            docConfig.setStale(false);
             continue;
           }
 

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerUnitTests.kt
@@ -18,7 +18,6 @@ import org.bson.BsonString
 import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.configuration.CodecRegistries
 import org.bson.Document
-import org.bson.conversions.Bson
 import org.junit.After
 
 import org.junit.Assert.assertEquals

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerUnitTests.kt
@@ -1864,4 +1864,66 @@ class DataSynchronizerUnitTests {
 
         verify(ctx.collectionMock, times(1)).find(any())
     }
+
+    @Test
+    fun testMissingDocumentThatAppearsLaterAsInsertEvent() {
+        val ctx = harness.freshTestContext()
+
+        ctx.reconfigure()
+
+        ctx.dataSynchronizer.stop()
+
+        ctx.dataSynchronizer.syncDocumentFromRemote(ctx.namespace, ctx.testDocumentId)
+
+        ctx.doSyncPass()
+
+        val mockEmptyFindResult = mock(CoreRemoteFindIterableImpl::class.java)
+        `when`(mockEmptyFindResult
+                .into(any(MutableCollection::class.java as Class<MutableCollection<Any>>)))
+                .thenReturn(HashSet<Any>())
+        `when`(ctx.collectionMock.find(any()))
+                .thenReturn(mockEmptyFindResult as CoreRemoteFindIterable<BsonDocument>)
+
+
+        ctx.queueConsumableRemoteInsertEvent()
+        ctx.doSyncPass()
+        ctx.waitForEvents()
+
+        verify(ctx.collectionMock, times(1)).find(any())
+
+        val localDoc = ctx.dataSynchronizer
+                .find(ctx.namespace, BsonDocument().append("_id", ctx.testDocumentId)).firstOrNull()
+        assertEquals(ctx.testDocumentId, localDoc?.get("_id"))
+    }
+
+    @Test
+    fun testMissingDocumentThatAppearsLaterAsUpdateEvent() {
+        val ctx = harness.freshTestContext()
+
+        ctx.reconfigure()
+
+        ctx.dataSynchronizer.stop()
+
+        ctx.dataSynchronizer.syncDocumentFromRemote(ctx.namespace, ctx.testDocumentId)
+
+        ctx.doSyncPass()
+
+        val mockEmptyFindResult = mock(CoreRemoteFindIterableImpl::class.java)
+        `when`(mockEmptyFindResult
+                .into(any(MutableCollection::class.java as Class<MutableCollection<Any>>)))
+                .thenReturn(HashSet<Any>())
+        `when`(ctx.collectionMock.find(any()))
+                .thenReturn(mockEmptyFindResult as CoreRemoteFindIterable<BsonDocument>)
+
+
+        ctx.queueConsumableRemoteUpdateEvent()
+        ctx.doSyncPass()
+        ctx.waitForEvents()
+
+        verify(ctx.collectionMock, times(1)).find(any())
+
+        val localDoc = ctx.dataSynchronizer
+                .find(ctx.namespace, BsonDocument().append("_id", ctx.testDocumentId)).firstOrNull()
+        assertEquals(ctx.testDocumentId, localDoc?.get("_id"))
+    }
 }


### PR DESCRIPTION
This addresses the user-reported but that causes an unwanted "polling" behavior when an ID is synced but the remote collection does not contain information about the document with the corresponding ID (or the document is not visible due to rules).