### PR TITLE
STITCH-2509 fix some logic issues with multi-user authentication

### DIFF
--- a/android/core/src/main/java/com/mongodb/stitch/android/core/auth/internal/StitchAuthImpl.java
+++ b/android/core/src/main/java/com/mongodb/stitch/android/core/auth/internal/StitchAuthImpl.java
@@ -132,7 +132,7 @@ public final class StitchAuthImpl extends CoreStitchAuth<StitchUser> implements 
         new Callable<Void>() {
           @Override
           public Void call() {
-            logoutInternal(userId);
+            logoutUserWithIdInternal(userId);
             return null;
           }
         });
@@ -156,7 +156,7 @@ public final class StitchAuthImpl extends CoreStitchAuth<StitchUser> implements 
         new Callable<Void>() {
           @Override
           public Void call() {
-            removeUserInternal(userId);
+            removeUserWithIdInternal(userId);
             return null;
           }
         });

--- a/core/sdk/src/main/java/com/mongodb/stitch/core/StitchClientErrorCode.java
+++ b/core/sdk/src/main/java/com/mongodb/stitch/core/StitchClientErrorCode.java
@@ -25,6 +25,10 @@ public enum StitchClientErrorCode {
   MUST_AUTHENTICATE_FIRST("method called requires being authenticated"),
   USER_NO_LONGER_VALID(
       "user instance being accessed is no longer valid; please get a new user with auth.getUser()"),
+  USER_NOT_FOUND("user not found in list of users"),
+  USER_NOT_LOGGED_IN(
+      "cannot make the active user a logged out user; please use loginWithCredential() to "
+       + " switch to this user"),
   COULD_NOT_LOAD_PERSISTED_AUTH_INFO("failed to load stored auth information for Stitch"),
   COULD_NOT_PERSIST_AUTH_INFO("failed to save auth information for Stitch");
 

--- a/core/sdk/src/main/java/com/mongodb/stitch/core/auth/internal/AuthInfo.java
+++ b/core/sdk/src/main/java/com/mongodb/stitch/core/auth/internal/AuthInfo.java
@@ -27,6 +27,7 @@ import com.mongodb.stitch.core.internal.common.Storage;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -115,12 +116,12 @@ public class AuthInfo {
     storage.set(ACTIVE_USER_STORAGE_NAME, rawInfo);
   }
 
-  static void writeLoggedInUsersAuthInfoToStorage(
-      final LinkedList<AuthInfo> loggedInUsersAuthInfo,
+  static void writeCurrentUsersToStorage(
+      final Collection<AuthInfo> allUsersAuthInfo,
       final Storage storage
   ) throws IOException {
     final List<AuthInfo> authInfos = new ArrayList<>();
-    for (final AuthInfo authInfo : loggedInUsersAuthInfo) {
+    for (final AuthInfo authInfo : allUsersAuthInfo) {
       authInfos.add(new StoreAuthInfo(
           authInfo.userId,
           authInfo.deviceId,
@@ -138,6 +139,19 @@ public class AuthInfo {
   AuthInfo loggedOut() {
     return new AuthInfo(
         userId, deviceId, null, null, loggedInProviderType, loggedInProviderName, userProfile);
+  }
+
+  AuthInfo withClearedUser() {
+    return new AuthInfo(
+        null, deviceId, null, null, null, null, null);
+  }
+
+  AuthInfo withAuthProvider(
+      final String providerType,
+      final String providerName
+  ) {
+    return new AuthInfo(
+        userId, deviceId, accessToken, refreshToken, providerType, providerName, userProfile);
   }
 
   AuthInfo merge(final AuthInfo newInfo) {
@@ -181,6 +195,10 @@ public class AuthInfo {
 
   public boolean isLoggedIn() {
     return accessToken != null && refreshToken != null;
+  }
+
+  public boolean hasUser() {
+    return userId != null;
   }
 
   @Override

--- a/core/sdk/src/main/java/com/mongodb/stitch/core/auth/internal/CoreStitchAuth.java
+++ b/core/sdk/src/main/java/com/mongodb/stitch/core/auth/internal/CoreStitchAuth.java
@@ -24,6 +24,7 @@ import com.mongodb.stitch.core.StitchServiceErrorCode;
 import com.mongodb.stitch.core.StitchServiceException;
 import com.mongodb.stitch.core.auth.StitchCredential;
 import com.mongodb.stitch.core.auth.internal.models.ApiCoreUserProfile;
+import com.mongodb.stitch.core.auth.providers.anonymous.AnonymousAuthProvider;
 import com.mongodb.stitch.core.internal.common.BsonUtils;
 import com.mongodb.stitch.core.internal.common.IoUtils;
 import com.mongodb.stitch.core.internal.common.StitchObjectMapper;
@@ -40,6 +41,7 @@ import com.mongodb.stitch.core.internal.net.Stream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -69,7 +71,7 @@ public abstract class CoreStitchAuth<StitchUserT extends CoreStitchUser>
   private final StitchAuthRoutes authRoutes;
   private final Storage storage;
   private Thread refresherThread;
-  private LinkedList<AuthInfo> loggedInUsersAuthInfoList;
+  private LinkedHashMap<String, AuthInfo> allUsersAuthInfo;
   private StitchUserT activeUser;
   private AuthInfo activeUserAuthInfo;
   private Lock authLock;
@@ -84,16 +86,18 @@ public abstract class CoreStitchAuth<StitchUserT extends CoreStitchUser>
     this.storage = storage;
     this.authLock = new ReentrantLock();
 
-    final List<AuthInfo> loggedInUsersAuthInfo;
+    final List<AuthInfo> allUsersAuthInfoList;
     try {
-      loggedInUsersAuthInfo = AuthInfo.readCurrentUsersFromStorage(storage);
+      allUsersAuthInfoList = AuthInfo.readCurrentUsersFromStorage(storage);
     } catch (final IOException e) {
       throw new StitchClientException(StitchClientErrorCode.COULD_NOT_LOAD_PERSISTED_AUTH_INFO);
     }
 
-    this.loggedInUsersAuthInfoList = new LinkedList<>();
-    if (loggedInUsersAuthInfo != null) {
-      this.loggedInUsersAuthInfoList.addAll(loggedInUsersAuthInfo);
+    this.allUsersAuthInfo = new LinkedHashMap<>();
+    if (allUsersAuthInfoList != null) {
+      for (final AuthInfo authInfo : allUsersAuthInfoList) {
+        this.allUsersAuthInfo.put(authInfo.getUserId(), authInfo);
+      }
     }
 
     try {
@@ -106,7 +110,7 @@ public abstract class CoreStitchAuth<StitchUserT extends CoreStitchUser>
       this.activeUserAuthInfo = AuthInfo.empty();
     }
 
-    if (this.activeUserAuthInfo.getUserId() != null) {
+    if (this.activeUserAuthInfo.hasUser()) {
       this.activeUser = getUserFactory().makeUser(
           this.activeUserAuthInfo.getUserId(),
           this.activeUserAuthInfo.getDeviceId(),
@@ -162,7 +166,7 @@ public abstract class CoreStitchAuth<StitchUserT extends CoreStitchUser>
 
   public synchronized LinkedList<StitchUserT> listUsers() {
     final LinkedList<StitchUserT> userSet = new LinkedList<>();
-    for (final AuthInfo authInfo : loggedInUsersAuthInfoList) {
+    for (final AuthInfo authInfo : this.allUsersAuthInfo.values()) {
       userSet.add(getUserFactory().makeUser(
           authInfo.getUserId(),
           authInfo.getDeviceId(),
@@ -182,11 +186,19 @@ public abstract class CoreStitchAuth<StitchUserT extends CoreStitchUser>
    * @return the response to the request, successful or not.
    */
   public synchronized Response doAuthenticatedRequest(final StitchAuthRequest stitchReq) {
+    return doAuthenticatedRequest(stitchReq, activeUserAuthInfo);
+  }
+
+  /**
+   * Internal method which performs the authenticated request by preparing the auth request with
+   * the provided auth info and request.
+   */
+  private synchronized Response doAuthenticatedRequest(
+      final StitchAuthRequest stitchReq,
+      final AuthInfo authInfo
+  ) {
     try {
-      if (!stitchReq.getHeaders().containsKey(Headers.AUTHORIZATION)) {
-        return requestClient.doRequest(prepareAuthRequest(stitchReq, activeUserAuthInfo));
-      }
-      return requestClient.doRequest(stitchReq);
+      return requestClient.doRequest(prepareAuthRequest(stitchReq, authInfo));
     } catch (final StitchServiceException ex) {
       return handleAuthFailure(ex, stitchReq);
     }
@@ -258,33 +270,37 @@ public abstract class CoreStitchAuth<StitchUserT extends CoreStitchUser>
   }
 
   public synchronized StitchUserT switchToUserWithId(final String userId)
-      throws IllegalArgumentException {
+      throws StitchClientException {
     authLock.lock();
     try {
-      for (final AuthInfo authInfo : loggedInUsersAuthInfoList) {
-        if (authInfo.getUserId().equals(userId)) {
-          this.activeUserAuthInfo = authInfo;
-          this.activeUser = getUserFactory().makeUser(
-              activeUserAuthInfo.getUserId(),
-              activeUserAuthInfo.getDeviceId(),
-              activeUserAuthInfo.getLoggedInProviderType(),
-              activeUserAuthInfo.getLoggedInProviderName(),
-              activeUserAuthInfo.getUserProfile(),
-              activeUserAuthInfo.isLoggedIn());
-          onAuthEvent();
-          try {
-            AuthInfo.writeActiveUserAuthInfoToStorage(this.activeUserAuthInfo, this.storage);
-          } catch (IOException e) {
-            throw new StitchClientException(StitchClientErrorCode.COULD_NOT_PERSIST_AUTH_INFO);
-          }
-          return this.activeUser;
-        }
+      final AuthInfo authInfo = findAuthInfoById(userId);
+      if (!authInfo.isLoggedIn()) {
+        throw new StitchClientException(StitchClientErrorCode.USER_NOT_LOGGED_IN);
       }
+
+      // persist auth info storage before actually setting auth state so that
+      // if the persist call throws, we are not in an inconsistent state
+      // with storage
+      try {
+        AuthInfo.writeActiveUserAuthInfoToStorage(authInfo, this.storage);
+      } catch (IOException e) {
+        throw new StitchClientException(StitchClientErrorCode.COULD_NOT_PERSIST_AUTH_INFO);
+      }
+
+      this.activeUserAuthInfo = authInfo;
+      this.activeUser = getUserFactory().makeUser(
+          activeUserAuthInfo.getUserId(),
+          activeUserAuthInfo.getDeviceId(),
+          activeUserAuthInfo.getLoggedInProviderType(),
+          activeUserAuthInfo.getLoggedInProviderName(),
+          activeUserAuthInfo.getUserProfile(),
+          activeUserAuthInfo.isLoggedIn());
+      onAuthEvent();
+
+      return this.activeUser;
     } finally {
       authLock.unlock();
     }
-
-    throw new IllegalArgumentException(String.format("User with id %s not found", userId));
   }
 
   protected StitchUserT loginWithCredentialInternal(final StitchCredential credential) {
@@ -294,13 +310,13 @@ public abstract class CoreStitchAuth<StitchUserT extends CoreStitchUser>
         return doLogin(credential, false);
       }
 
-      for (final AuthInfo authInfo : loggedInUsersAuthInfoList) {
-        if (credential.getProviderCapabilities().getReusesExistingSession()
-            && credential.getProviderType().equals(authInfo.getLoggedInProviderType())) {
-          return switchToUserWithId(authInfo.getUserId());
+      if (credential.getProviderCapabilities().getReusesExistingSession()) {
+        for (final AuthInfo authInfo : this.allUsersAuthInfo.values()) {
+          if (authInfo.getLoggedInProviderType().equals(credential.getProviderType())) {
+            return switchToUserWithId(authInfo.getUserId());
+          }
         }
       }
-
 
       return doLogin(credential, false);
     } finally {
@@ -327,10 +343,12 @@ public abstract class CoreStitchAuth<StitchUserT extends CoreStitchUser>
       return;
     }
 
-    logoutInternal(activeUser.getId());
+    logoutUserWithIdInternal(activeUser.getId());
   }
 
-  protected synchronized void logoutInternal(final String userId) throws IllegalArgumentException {
+  protected synchronized void logoutUserWithIdInternal(
+      final String userId
+  ) throws StitchClientException {
     authLock.lock();
     try {
       final AuthInfo authInfo = findAuthInfoById(userId);
@@ -343,13 +361,12 @@ public abstract class CoreStitchAuth<StitchUserT extends CoreStitchUser>
       } catch (final StitchServiceException ex) {
         // Do nothing
       } finally {
-        clearUser(authInfo);
-        // add logged out user to front of queue
-        loggedInUsersAuthInfoList.addFirst(authInfo.loggedOut());
-        try {
-          AuthInfo.writeLoggedInUsersAuthInfoToStorage(loggedInUsersAuthInfoList, storage);
-        } catch (final IOException e) {
-          // Do nothing
+        clearUserAuth(authInfo.getUserId());
+
+        // if the user was anonymous, delete the user, since you can't log back
+        // in to an anonymous user after they have logged out.
+        if (authInfo.getLoggedInProviderType().equals(AnonymousAuthProvider.TYPE)) {
+          this.removeUserWithIdInternal(userId);
         }
       }
     } finally {
@@ -362,10 +379,10 @@ public abstract class CoreStitchAuth<StitchUserT extends CoreStitchUser>
       return;
     }
 
-    removeUserInternal(activeUser.getId());
+    removeUserWithIdInternal(activeUser.getId());
   }
 
-  protected synchronized void removeUserInternal(final String userId) {
+  protected synchronized void removeUserWithIdInternal(final String userId) {
     authLock.lock();
     try {
       final AuthInfo authInfo = findAuthInfoById(userId);
@@ -375,8 +392,15 @@ public abstract class CoreStitchAuth<StitchUserT extends CoreStitchUser>
         }
       } catch (final StitchServiceException ex) {
         // Do nothing
-      } finally {
-        clearUser(authInfo);
+      }
+
+      clearUserAuth(authInfo.getUserId());
+      this.allUsersAuthInfo.remove(userId);
+
+      try {
+        AuthInfo.writeCurrentUsersToStorage(this.allUsersAuthInfo.values(), this.storage);
+      } catch (IOException e) {
+        throw new StitchClientException(StitchClientErrorCode.COULD_NOT_PERSIST_AUTH_INFO);
       }
     } finally {
       authLock.unlock();
@@ -426,7 +450,7 @@ public abstract class CoreStitchAuth<StitchUserT extends CoreStitchUser>
     // using a refresh token implies we cannot refresh anything, so clear auth and
     // notify
     if (req.getUseRefreshToken() || !req.getShouldRefreshOnFailure()) {
-      clearActiveUser();
+      clearActiveUserAuth();
       throw ex;
     }
 
@@ -445,16 +469,13 @@ public abstract class CoreStitchAuth<StitchUserT extends CoreStitchUser>
     // using a refresh token implies we cannot refresh anything, so clear auth and
     // notify
     if (req.getUseRefreshToken() || !req.getShouldRefreshOnFailure()) {
-      clearActiveUser();
+      clearActiveUserAuth();
       throw ex;
     }
 
     tryRefreshAccessToken(req.getStartedAt());
 
-    return doAuthenticatedRequest(
-        prepareAuthRequest(
-            req.builder().withShouldRefreshOnFailure(false).build(),
-            activeUserAuthInfo));
+    return doAuthenticatedRequest(req.builder().withShouldRefreshOnFailure(false).build());
   }
 
   // use this critical section to create a queue of pending outbound requests
@@ -492,8 +513,7 @@ public abstract class CoreStitchAuth<StitchUserT extends CoreStitchUser>
           .withPath(authRoutes.getSessionRoute())
           .withMethod(Method.POST);
 
-      final Response response = doAuthenticatedRequest(
-          prepareAuthRequest(reqBuilder.build(), activeUserAuthInfo));
+      final Response response = doAuthenticatedRequest(reqBuilder.build(), activeUserAuthInfo);
 
       try {
         final AuthInfo partialInfo = AuthInfo.readFromApi(response.getBody());
@@ -546,7 +566,7 @@ public abstract class CoreStitchAuth<StitchUserT extends CoreStitchUser>
     }
     final StitchAuthDocRequest linkRequest =
         new StitchAuthDocRequest(reqBuilder.build(), reqBuilder.getDocument());
-    return doAuthenticatedRequest(prepareAuthRequest(linkRequest, activeUserAuthInfo));
+    return doAuthenticatedRequest(linkRequest);
   }
 
   private StitchUserT processLoginResponse(
@@ -587,18 +607,29 @@ public abstract class CoreStitchAuth<StitchUserT extends CoreStitchUser>
 
     final StitchUserProfileImpl profile;
     try {
-      profile = doGetUserProfile(activeUserAuthInfo);
+      profile = doGetUserProfile();
     } catch (final Exception ex) {
-      // If this was a link request or another user is logged in,
+      // If this was a link request or there was an active user logged in,
       // back out of setting authInfo and reset any created user. This
       // will keep the currently logged in user logged in if the profile
       // request failed, and in this particular edge case the user is
       // linked, but they are logged in with their older credentials.
-      if (asLinkRequest || !loggedInUsersAuthInfoList.isEmpty()) {
+      if (asLinkRequest || oldActiveUserInfo.hasUser()) {
+        final AuthInfo linkedAuthInfo = activeUserAuthInfo;
         activeUserAuthInfo = oldActiveUserInfo;
         activeUser = oldActiveUser;
+
+        // to prevent the case where this user gets removed when logged out
+        // in the future because the original provider type was anonymous,
+        // make sure the auth info reflects the new logged in provider type
+        if (asLinkRequest) {
+          this.activeUserAuthInfo = this.activeUserAuthInfo.withAuthProvider(
+              linkedAuthInfo.getLoggedInProviderType(),
+              linkedAuthInfo.getLoggedInProviderName()
+          );
+        }
       } else { // otherwise if this was a normal login request, log the user out
-        clearActiveUser();
+        clearActiveUserAuth();
       }
 
       throw ex;
@@ -619,22 +650,28 @@ public abstract class CoreStitchAuth<StitchUserT extends CoreStitchUser>
     try {
       AuthInfo.writeActiveUserAuthInfoToStorage(newAuthInfo, storage);
 
-      // if this is a link request, remove the old active info
-      // and replace it with the updated version
-      if (asLinkRequest || loggedInUsersAuthInfoList.contains(newAuthInfo)) {
-        loggedInUsersAuthInfoList.remove(oldActiveUserInfo);
-      }
+      // this replaces any old info that may have
+      // existed for this user if this was a link request, or if this
+      // user already existed in the list of all users
+      this.allUsersAuthInfo.put(newAuthInfo.getUserId(), newAuthInfo);
 
-      loggedInUsersAuthInfoList.add(newAuthInfo);
-      AuthInfo.writeLoggedInUsersAuthInfoToStorage(loggedInUsersAuthInfoList, storage);
+      AuthInfo.writeCurrentUsersToStorage(allUsersAuthInfo.values(), storage);
     } catch (final IOException e) {
-      // Back out of setting authInfo
+      // Back out of setting authInfo with this new user
       activeUserAuthInfo = oldActiveUserInfo;
       activeUser = null;
-      loggedInUsersAuthInfoList.remove(newAuthInfo);
+
+      // delete the new partial auth info from the list of all users if
+      // if the new auth info is not the same user as the older user
+      if (!newAuthInfo.getUserId().equals(oldActiveUserInfo.getUserId())
+           && newAuthInfo.getUserId() != null) {
+        this.allUsersAuthInfo.remove(newAuthInfo.getUserId());
+      }
+
       throw new StitchClientException(StitchClientErrorCode.COULD_NOT_PERSIST_AUTH_INFO);
     }
 
+    // set the active user info to the new auth info and new user with profile
     activeUserAuthInfo = newAuthInfo;
     activeUser =
         getUserFactory()
@@ -649,12 +686,11 @@ public abstract class CoreStitchAuth<StitchUserT extends CoreStitchUser>
     return activeUser;
   }
 
-  private StitchUserProfileImpl doGetUserProfile(final AuthInfo authInfo) {
+  private StitchUserProfileImpl doGetUserProfile() {
     final StitchAuthRequest.Builder reqBuilder = new StitchAuthRequest.Builder();
     reqBuilder.withMethod(Method.GET).withPath(authRoutes.getProfileRoute());
 
-    final Response response = doAuthenticatedRequest(
-        prepareAuthRequest(reqBuilder.build(), authInfo));
+    final Response response = doAuthenticatedRequest(reqBuilder.build());
 
     try {
       return StitchObjectMapper.getInstance()
@@ -667,34 +703,43 @@ public abstract class CoreStitchAuth<StitchUserT extends CoreStitchUser>
   private void doLogout(final AuthInfo authInfo) {
     final StitchAuthRequest.Builder reqBuilder = new StitchAuthRequest.Builder();
     reqBuilder.withRefreshToken().withPath(authRoutes.getSessionRoute()).withMethod(Method.DELETE);
-    this.doAuthenticatedRequest(prepareAuthRequest(reqBuilder.build(), authInfo));
+    this.doAuthenticatedRequest(reqBuilder.build(), authInfo);
   }
 
-  private synchronized void clearActiveUser() {
+  private synchronized void clearActiveUserAuth() {
     if (!isLoggedIn()) {
       return;
     }
 
-    loggedInUsersAuthInfoList.remove(activeUserAuthInfo);
-
-    activeUserAuthInfo = activeUserAuthInfo.loggedOut();
-    activeUser = null;
-
-    try {
-      AuthInfo.writeActiveUserAuthInfoToStorage(activeUserAuthInfo, storage);
-    } catch (final IOException e) {
-      throw new StitchClientException(StitchClientErrorCode.COULD_NOT_PERSIST_AUTH_INFO);
-    }
-    onAuthEvent();
+    this.clearUserAuth(activeUserAuthInfo.getUserId());
   }
 
-  private synchronized void clearUser(final AuthInfo authInfo) {
-    try {
-      if (loggedInUsersAuthInfoList.remove(authInfo)) {
-        AuthInfo.writeLoggedInUsersAuthInfoToStorage(loggedInUsersAuthInfoList, storage);
+  private synchronized void clearUserAuth(final String userId) {
+    final AuthInfo unclearedAuthInfo = this.allUsersAuthInfo.get(userId);
+    if (unclearedAuthInfo == null) {
+      // this doesn't necessarily mean there's an error. we could be in a
+      // provisional state where the profile request failed and we're just
+      // trying to log out the active user.
+      if (this.activeUserAuthInfo.getUserId() != userId) {
+        // only throw if this ID is not the active user either
+        throw new StitchClientException(StitchClientErrorCode.USER_NOT_FOUND);
       }
-      if (activeUserAuthInfo.equals(authInfo)) {
-        clearActiveUser();
+    }
+
+    try {
+      if (unclearedAuthInfo != null) {
+        this.allUsersAuthInfo.put(userId, unclearedAuthInfo.loggedOut());
+        AuthInfo.writeCurrentUsersToStorage(this.allUsersAuthInfo.values(), storage);
+      }
+
+      // if the auth info we're clearing is also the active user's auth info,
+      // clear the active user's auth as well
+      if (activeUserAuthInfo.hasUser() && activeUserAuthInfo.getUserId().equals(userId)) {
+        this.activeUserAuthInfo = this.activeUserAuthInfo.withClearedUser();
+        this.activeUser = null;
+
+        AuthInfo.writeActiveUserAuthInfoToStorage(this.activeUserAuthInfo, this.storage);
+        this.onAuthEvent();
       }
     } catch (final IOException e) {
       throw new StitchClientException(StitchClientErrorCode.COULD_NOT_PERSIST_AUTH_INFO);
@@ -719,14 +764,13 @@ public abstract class CoreStitchAuth<StitchUserT extends CoreStitchUser>
     return authRoutes;
   }
 
-  private AuthInfo findAuthInfoById(final String userId) throws IllegalArgumentException {
-    for (final AuthInfo authInfo : loggedInUsersAuthInfoList) {
-      if (authInfo.getUserId().equals(userId)) {
-        return authInfo;
-      }
+  private AuthInfo findAuthInfoById(final String userId) throws StitchClientException {
+    final AuthInfo authInfo = this.allUsersAuthInfo.get(userId);
+    if (authInfo == null) {
+      throw new StitchClientException(StitchClientErrorCode.USER_NOT_FOUND);
     }
 
-    throw new IllegalArgumentException("user id not found");
+    return authInfo;
   }
 
   private static class AuthStreamFields {

--- a/core/sdk/src/main/java/com/mongodb/stitch/core/auth/internal/CoreStitchAuth.java
+++ b/core/sdk/src/main/java/com/mongodb/stitch/core/auth/internal/CoreStitchAuth.java
@@ -41,8 +41,8 @@ import com.mongodb.stitch.core.internal.net.Stream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.Lock;
@@ -164,8 +164,8 @@ public abstract class CoreStitchAuth<StitchUserT extends CoreStitchUser>
     return activeUser;
   }
 
-  public synchronized LinkedList<StitchUserT> listUsers() {
-    final LinkedList<StitchUserT> userSet = new LinkedList<>();
+  public synchronized List<StitchUserT> listUsers() {
+    final ArrayList<StitchUserT> userSet = new ArrayList<>();
     for (final AuthInfo authInfo : this.allUsersAuthInfo.values()) {
       userSet.add(getUserFactory().makeUser(
           authInfo.getUserId(),
@@ -716,14 +716,12 @@ public abstract class CoreStitchAuth<StitchUserT extends CoreStitchUser>
 
   private synchronized void clearUserAuth(final String userId) {
     final AuthInfo unclearedAuthInfo = this.allUsersAuthInfo.get(userId);
-    if (unclearedAuthInfo == null) {
+    if (unclearedAuthInfo == null && !this.activeUserAuthInfo.getUserId().equals(userId)) {
       // this doesn't necessarily mean there's an error. we could be in a
       // provisional state where the profile request failed and we're just
       // trying to log out the active user.
-      if (this.activeUserAuthInfo.getUserId() != userId) {
-        // only throw if this ID is not the active user either
-        throw new StitchClientException(StitchClientErrorCode.USER_NOT_FOUND);
-      }
+      // only throw if this ID is not the active user either
+      throw new StitchClientException(StitchClientErrorCode.USER_NOT_FOUND);
     }
 
     try {

--- a/core/sdk/src/test/java/com/mongodb/stitch/core/auth/internal/CoreStitchAuthUnitTests.java
+++ b/core/sdk/src/test/java/com/mongodb/stitch/core/auth/internal/CoreStitchAuthUnitTests.java
@@ -211,7 +211,7 @@ public class CoreStitchAuthUnitTests {
     final CoreStitchUser user3 =
         auth.loginWithCredentialInternal(new UserPasswordCredential("bye", "there"));
 
-    assertEquals(auth.listUsers().getLast(), user3);
+    assertEquals(auth.listUsers().get(2), user3);
     assertTrue(auth.isLoggedIn());
 
     auth.logoutInternal();
@@ -297,14 +297,14 @@ public class CoreStitchAuthUnitTests {
     final CoreStitchUser user3 =
         auth.loginWithCredentialInternal(new UserPasswordCredential("bye", "there"));
 
-    assertEquals(auth.listUsers().getLast(), user3);
+    assertEquals(auth.listUsers().get(2), user3);
     assertTrue(auth.isLoggedIn());
 
     auth.removeUserInternal();
 
     // assert that though one user is logged out, two users are still listed
     assertEquals(auth.listUsers().size(), 2);
-    assertEquals(auth.listUsers().getLast(), user2);
+    assertEquals(auth.listUsers().get(1), user2);
 
     final ArgumentCaptor<StitchRequest> reqArgs = ArgumentCaptor.forClass(StitchRequest.class);
     verify(requestClient, times(7)).doRequest(reqArgs.capture());
@@ -331,10 +331,10 @@ public class CoreStitchAuthUnitTests {
 
     // assert that there is one user left
     assertEquals(auth.listUsers().size(), 1);
-    assertEquals(auth.listUsers().getLast(), user1);
+    assertEquals(auth.listUsers().get(0), user1);
 
     // assert that we can remove the user without switching to it
-    auth.removeUserWithIdInternal(auth.listUsers().getLast().getId());
+    auth.removeUserWithIdInternal(user1.getId());
     assertEquals(auth.listUsers().size(), 0);
 
     assertFalse(auth.isLoggedIn());
@@ -346,7 +346,7 @@ public class CoreStitchAuthUnitTests {
         user2, auth.loginWithCredentialInternal(new UserPasswordCredential("hi", "there")));
 
     assertEquals(auth.listUsers().size(), 1);
-    assertEquals(auth.listUsers().getLast(), user2);
+    assertEquals(auth.listUsers().get(0), user2);
 
     assertTrue(auth.isLoggedIn());
   }

--- a/server/core/src/main/java/com/mongodb/stitch/server/core/auth/internal/StitchAuthImpl.java
+++ b/server/core/src/main/java/com/mongodb/stitch/server/core/auth/internal/StitchAuthImpl.java
@@ -77,7 +77,7 @@ public final class StitchAuthImpl extends CoreStitchAuth<StitchUser> implements 
 
   @Override
   public void logoutUserWithId(final String userId) {
-    logoutInternal(userId);
+    logoutUserWithIdInternal(userId);
   }
 
   @Override
@@ -87,7 +87,7 @@ public final class StitchAuthImpl extends CoreStitchAuth<StitchUser> implements 
 
   @Override
   public void removeUserWithId(final String userId) {
-    removeUserInternal(userId);
+    removeUserWithIdInternal(userId);
   }
 
   @Override


### PR DESCRIPTION
This should bring the Android multi-user logic to parity with the JS PR logic in https://github.com/mongodb/stitch-js-sdk/pull/216. 

Fixes made here include the following:
* various internal naming changes to be consistent with Android
* new doAuthenticatedRequest overload to do authenticated requests on behalf of another user to prevent many prepareAuthRequest calls
* adding `USER_NOT_FOUND` and `USER_NOT_LOGGED_IN` error codes
* storing the user list as an ordered map (LinkedHashMap) rather than a LinkedList
* persisting device id when there is no active user
* removing users when not logged in
* removing anonymous users when they are logged out
* handling user linking profile failure edge case 
* various changes to the order of logic in `CoreStitchAuth`
* various test changes

