### PR TITLE
Fix javadoc 11.0.2+ 'unnamed module' error by specifying the source flag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -467,6 +467,9 @@ rootProject.gradle.projectsEvaluated {
         options.addStringOption("examplesPath", "contrib/docs-examples/")
         options.addStringOption("manifestPath", "build/docs/examplesManifest.json")
 
+        // Appease 'unnamed module' error on javadoc 11.0.2+
+        options.addStringOption("source", "8")
+
         String androidDocsDir = ""
         subprojects {
             project.tasks.withType(Javadoc).each { javadocTask ->


### PR DESCRIPTION
javadoc 11.0.2 (not 11.0.1) was reporting this error:

> Task :core:stitch-core-sdk:javadoc
javadoc: error - The code being documented uses modules but the packages defined in https://docs.oracle.com/javase/8/docs/api/ are in the unnamed module.

Specifying the source java version to javadoc makes this error go away.