### PR TITLE
DOCSP-4911 Add code example snippets as integration tests

### DIFF
--- a/android/examples/snippets/build.gradle
+++ b/android/examples/snippets/build.gradle
@@ -1,0 +1,45 @@
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+apply plugin: 'digital.wup.android-maven-publish'
+apply plugin: 'jacoco-android'
+apply plugin: 'com.jfrog.bintray'
+
+ext.pomDisplayName = "Code example snippet tests"
+
+buildscript {
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'digital.wup:android-maven-publish:3.6.2'
+        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
+    }
+}
+
+android {
+    compileSdkVersion target_api
+    defaultConfig {
+        minSdkVersion min_api
+        targetSdkVersion target_api
+
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+
+        Properties properties = new Properties()
+        File file = project.rootProject.file('local.properties')
+        if (file.exists()) {
+            properties.load(project.rootProject.file('local.properties').newDataInputStream())
+        }
+        testInstrumentationRunnerArgument "test.stitch.mongodbURI", properties.getProperty("test.stitch.mongodbURI", "mongodb://localhost:26000")
+    }
+}
+
+dependencies {
+    api project(':core:core-services:stitch-core-services-mongodb-remote')
+    api project(':android:android-services:stitch-android-services-mongodb-local')
+
+    androidTestImplementation project(':android:stitch-android-testutils')
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    androidTestCompile project(path: ':android:android-services:stitch-android-services-mongodb-remote')
+}
+

--- a/android/examples/snippets/src/androidTest/java/com/mongodb/stitch/android/examples/snippets/RemoteMongoClientExamples.java
+++ b/android/examples/snippets/src/androidTest/java/com/mongodb/stitch/android/examples/snippets/RemoteMongoClientExamples.java
@@ -1,0 +1,41 @@
+package com.mongodb.stitch.android.examples.snippets;
+
+import android.support.test.runner.AndroidJUnit4;
+import android.util.Log;
+
+import com.mongodb.stitch.android.core.Stitch;
+import com.mongodb.stitch.android.core.StitchAppClient;
+import com.mongodb.stitch.android.services.mongodb.remote.RemoteMongoClient;
+import com.mongodb.stitch.android.services.mongodb.remote.RemoteMongoCollection;
+import com.mongodb.stitch.android.services.mongodb.remote.RemoteMongoDatabase;
+import com.mongodb.stitch.android.testutils.BaseStitchAndroidIntTest;
+import com.mongodb.stitch.core.admin.apps.AppResponse;
+
+import org.bson.Document;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class RemoteMongoClientExamples extends BaseStitchAndroidIntTest {
+    private static final String TAG = "RemoteMongoClientExamples";
+
+    private StitchAppClient appClient;
+
+    @Before
+    public void setup() {
+        appClient = getAppClient(new AppResponse("reference-bqxza", "reference-bqxza", "reference-bqxza"));
+    }
+
+    @Test
+    public void RemoteMongoClient() {
+        // Find 20 documents in a collection
+        // Note: log in first -- see StitchAuth
+        RemoteMongoClient mongoClient = appClient.getServiceClient(RemoteMongoClient.factory, "mongodb-atlas");
+        RemoteMongoDatabase db = mongoClient.getDatabase("video");
+        RemoteMongoCollection<Document> movieDetails = db.getCollection("movieDetails");
+        movieDetails.find().limit(20).forEach(document -> {
+            Log.i(TAG, "Got document: " + document.toString());
+        });
+    }
+}

--- a/android/examples/snippets/src/androidTest/java/com/mongodb/stitch/android/examples/snippets/RemoteMongoCollectionExamples.java
+++ b/android/examples/snippets/src/androidTest/java/com/mongodb/stitch/android/examples/snippets/RemoteMongoCollectionExamples.java
@@ -1,0 +1,74 @@
+package com.mongodb.stitch.android.examples.snippets;
+
+import android.support.test.runner.AndroidJUnit4;
+import android.util.Log;
+
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.mongodb.stitch.android.core.Stitch;
+import com.mongodb.stitch.android.core.StitchAppClient;
+import com.mongodb.stitch.android.services.mongodb.remote.RemoteMongoClient;
+import com.mongodb.stitch.android.services.mongodb.remote.RemoteMongoCollection;
+import com.mongodb.stitch.android.services.mongodb.remote.RemoteMongoDatabase;
+import com.mongodb.stitch.android.testutils.BaseStitchAndroidIntTest;
+import com.mongodb.stitch.core.admin.apps.AppResponse;
+import com.mongodb.stitch.core.services.mongodb.remote.RemoteCountOptions;
+
+import org.bson.BsonRegularExpression;
+import org.bson.Document;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class RemoteMongoCollectionExamples extends BaseStitchAndroidIntTest {
+    private static final String TAG = "RemoteMongoCollectionExamples";
+
+    private StitchAppClient appClient;
+
+    @Before
+    public void setup() {
+        appClient = getAppClient(new AppResponse("reference-bqxza", "reference-bqxza", "reference-bqxza"));
+    }
+
+    @Test
+    public void RemoteMongoCollection() {
+        // Note: log in first -- see StitchAuth
+        // Get the Atlas client.
+        RemoteMongoClient mongoClient = appClient.getServiceClient(RemoteMongoClient.factory, "mongodb-atlas");
+        RemoteMongoDatabase db = mongoClient.getDatabase("video");
+        RemoteMongoCollection<Document> movieDetails = db.getCollection("movieDetails");
+
+        // Find 20 documents
+        movieDetails.find()
+                .projection(new Document().append("title", 1).append("year", 1))
+                .limit(20)
+                .forEach(document -> {
+                    // Print documents to the log.
+                    Log.i(TAG, "Got document: " + document.toString());
+                });
+    }
+
+    @Test
+    public void RemoteMongoCollection_count_Bson_RemoteCountOptions() {
+        // Get the Atlas client.
+        RemoteMongoClient mongoClient = appClient.getServiceClient(RemoteMongoClient.factory, "mongodb-atlas");
+        RemoteMongoDatabase db = mongoClient.getDatabase("video");
+        RemoteMongoCollection<Document> movieDetails = db.getCollection("movieDetails");
+
+        // Count all documents where title matches a regex up to a limit
+        movieDetails.count(
+                new Document().append("title", new BsonRegularExpression("^A")),
+                new RemoteCountOptions().limit(25)).addOnCompleteListener(new OnCompleteListener<Long>() {
+            @Override
+            public void onComplete(@android.support.annotation.NonNull Task<Long> task) {
+                if (!task.isSuccessful()) {
+                    Log.e(TAG, "Count failed", task.getException());
+                    return;
+                }
+                Log.i(TAG, "Count is " + task.getResult());
+            }
+        });
+
+    }
+}

--- a/android/examples/snippets/src/androidTest/java/com/mongodb/stitch/android/examples/snippets/RemoteMongoDatabaseExamples.java
+++ b/android/examples/snippets/src/androidTest/java/com/mongodb/stitch/android/examples/snippets/RemoteMongoDatabaseExamples.java
@@ -1,0 +1,41 @@
+package com.mongodb.stitch.android.examples.snippets;
+
+import android.support.test.runner.AndroidJUnit4;
+import android.util.Log;
+
+import com.mongodb.stitch.android.core.Stitch;
+import com.mongodb.stitch.android.core.StitchAppClient;
+import com.mongodb.stitch.android.services.mongodb.remote.RemoteMongoClient;
+import com.mongodb.stitch.android.services.mongodb.remote.RemoteMongoCollection;
+import com.mongodb.stitch.android.services.mongodb.remote.RemoteMongoDatabase;
+import com.mongodb.stitch.android.testutils.BaseStitchAndroidIntTest;
+import com.mongodb.stitch.core.admin.apps.AppResponse;
+
+import org.bson.Document;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class RemoteMongoDatabaseExamples extends BaseStitchAndroidIntTest {
+    private static final String TAG = "RemoteMongoDatabaseExamples";
+
+    private StitchAppClient appClient;
+
+    @Before
+    public void setup() {
+        appClient = getAppClient(new AppResponse("reference-bqxza", "reference-bqxza", "reference-bqxza"));
+    }
+
+    @Test
+    public void RemoteMongoDatabase() {
+        // Find 20 documents in a collection
+        // Note: log in first -- see StitchAuth
+        RemoteMongoClient mongoClient = appClient.getServiceClient(RemoteMongoClient.factory, "mongodb-atlas");
+        RemoteMongoDatabase db = mongoClient.getDatabase("video");
+        RemoteMongoCollection<Document> movieDetails = db.getCollection("movieDetails");
+        movieDetails.find().limit(20).forEach(document -> {
+            Log.i(TAG, "Got document: " + document.toString());
+        });
+    }
+}

--- a/android/examples/snippets/src/androidTest/java/com/mongodb/stitch/android/examples/snippets/StitchAppClientExamples.java
+++ b/android/examples/snippets/src/androidTest/java/com/mongodb/stitch/android/examples/snippets/StitchAppClientExamples.java
@@ -1,0 +1,68 @@
+package com.mongodb.stitch.android.examples.snippets;
+
+import android.support.test.runner.AndroidJUnit4;
+import android.util.Log;
+
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.mongodb.lang.NonNull;
+import com.mongodb.stitch.android.core.Stitch;
+import com.mongodb.stitch.android.core.StitchAppClient;
+import com.mongodb.stitch.android.core.auth.StitchUser;
+import com.mongodb.stitch.android.services.mongodb.remote.RemoteMongoClient;
+import com.mongodb.stitch.android.services.mongodb.remote.RemoteMongoCollection;
+import com.mongodb.stitch.android.services.mongodb.remote.RemoteMongoDatabase;
+import com.mongodb.stitch.android.testutils.BaseStitchAndroidIntTest;
+import com.mongodb.stitch.core.admin.apps.AppResponse;
+import com.mongodb.stitch.core.auth.providers.anonymous.AnonymousCredential;
+
+import org.bson.Document;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class StitchAppClientExamples extends BaseStitchAndroidIntTest {
+    private static final String TAG = "StitchClientExamples";
+
+    private StitchAppClient appClient;
+
+    @Before
+    public void setup() {
+        appClient = getAppClient(new AppResponse("reference-bqxza", "reference-bqxza", "reference-bqxza"));
+    }
+
+    @Test
+    public void StitchAppClient() {
+        // Get the default app client. This is automatically initialized by Stitch
+        // if there is a `stitch_client_app_id` value in the values/strings.xml file.
+
+        // StitchAppClient appClient = Stitch.getDefaultAppClient();
+
+        // Log in anonymously. Some form of login is required before we can read documents.
+        appClient.getAuth().loginWithCredential(new AnonymousCredential()).addOnCompleteListener(new OnCompleteListener<StitchUser>() {
+            @Override
+            public void onComplete(@NonNull Task<StitchUser> task) {
+                if (!task.isSuccessful()) {
+                    Log.e(TAG, "Failed to log in!", task.getException());
+                    return;
+                }
+
+                // Get the Atlas client.
+                RemoteMongoClient mongoClient = appClient.getServiceClient(RemoteMongoClient.factory, "mongodb-atlas");
+                RemoteMongoDatabase db = mongoClient.getDatabase("video");
+                RemoteMongoCollection<Document> movieDetails = db.getCollection("movieDetails");
+
+                // Find 20 documents
+                movieDetails.find()
+                        .projection(new Document().append("title", 1).append("year", 1))
+                        .limit(20)
+                        .forEach(document -> {
+                            // Print documents to the log.
+                            Log.i(TAG, "Got document: " + document.toString());
+                        });
+            }
+        });
+
+    }
+}

--- a/android/examples/snippets/src/androidTest/java/com/mongodb/stitch/android/examples/snippets/StitchAuthExamples.java
+++ b/android/examples/snippets/src/androidTest/java/com/mongodb/stitch/android/examples/snippets/StitchAuthExamples.java
@@ -1,0 +1,68 @@
+package com.mongodb.stitch.android.examples.snippets;
+
+import android.support.test.runner.AndroidJUnit4;
+import android.util.Log;
+
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.mongodb.lang.NonNull;
+import com.mongodb.stitch.android.core.StitchAppClient;
+import com.mongodb.stitch.android.core.auth.StitchAuth;
+import com.mongodb.stitch.android.core.auth.StitchUser;
+import com.mongodb.stitch.android.services.mongodb.remote.RemoteMongoClient;
+import com.mongodb.stitch.android.services.mongodb.remote.RemoteMongoCollection;
+import com.mongodb.stitch.android.services.mongodb.remote.RemoteMongoDatabase;
+import com.mongodb.stitch.android.testutils.BaseStitchAndroidIntTest;
+import com.mongodb.stitch.core.admin.apps.AppResponse;
+import com.mongodb.stitch.core.auth.providers.anonymous.AnonymousCredential;
+import com.mongodb.stitch.core.services.mongodb.remote.RemoteCountOptions;
+
+import org.bson.BsonRegularExpression;
+import org.bson.Document;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class StitchAuthExamples extends BaseStitchAndroidIntTest {
+    private static final String TAG = "StitchAuthExamples";
+
+    private StitchAppClient appClient;
+
+    @Before
+    public void setup() {
+        appClient = getAppClient(new AppResponse("reference-bqxza", "reference-bqxza", "reference-bqxza"));
+    }
+
+    @Test
+    public void loginWithCredential() {
+        StitchAuth auth = appClient.getAuth();
+
+        // The Stitch app is configured for Anonymous login in the Stitch UI
+        auth.loginWithCredential(new AnonymousCredential()).addOnCompleteListener(new OnCompleteListener<StitchUser>() {
+            @Override
+            public void onComplete(@NonNull Task<StitchUser> task) {
+                if (task.isSuccessful()) {
+                    Log.i(TAG, "Anonymous login successful!");
+                } else {
+                    Log.e(TAG, "Anonymous login failed!", task.getException());
+                }
+            }
+        });
+    }
+
+    @Test
+    public void logout() {
+        StitchAuth auth = appClient.getAuth();
+        auth.logout().addOnCompleteListener(new OnCompleteListener<Void>() {
+            @Override
+            public void onComplete(@NonNull Task<Void> task) {
+                if (task.isSuccessful()) {
+                    Log.i(TAG, "Successfully logged out!");
+                } else {
+                    Log.e(TAG, "Logout failed!", task.getException());
+                }
+            }
+        });
+    }
+}

--- a/android/examples/snippets/src/main/AndroidManifest.xml
+++ b/android/examples/snippets/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.mongodb.stitch.android.examples.snippets" />

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -49,3 +49,13 @@ The general publishing flow can be followed using `major` as the bump type in `b
     * You must run at least one ```mongod``` instance with replica sets initiated or a ```mongos``` instance with same locally on port 26000
     * You must run the Stitch server locally using the Android-specific configuration:
         ```--configFile ./etc/configs/test_config_sdk_base.json --configFile ./etc/configs/test_config_sdk_android.json```
+    * For example, here's how to start mongod (using mlaunch), start the Stitch server, then run the tests:
+```
+mlaunch init --replicaset --port 26000
+
+# in stitch source directory
+go run cmd/server/main.go --configFile ./etc/configs/test_config_sdk_base.json --configFile ./etc/configs/test_config_sdk_android.json
+
+# in android SDK directory
+./gradlew connectedDebugAndroidTest
+```

--- a/settings.gradle
+++ b/settings.gradle
@@ -43,6 +43,7 @@ include ':core:sdk',
         ':android:examples:stress-tests',
         ':android:examples:todo',
         ':android:examples:todo-sync',
+        ':android:examples:snippets',
         ':android:testutils'
 
 project(':core:sdk').name = 'stitch-core-sdk'
@@ -87,4 +88,5 @@ project(':android:examples:fcm').name = 'stitch-android-examples-fcm'
 project(':android:examples:todo').name = 'stitch-android-examples-todo'
 project(':android:examples:todo-sync').name = 'stitch-android-examples-todo-sync'
 project(':android:examples:stress-tests').name = 'stitch-android-examples-stress-tests'
+project(':android:examples:snippets').name = 'stitch-android-examples-snippets'
 project(':android:testutils').name = 'stitch-android-testutils'


### PR DESCRIPTION
These can be copied over to the contrib/docs-examples directory manually for now
upon change.

This adds a new module under the examples module called "snippets" which is
just a bunch of integration tests containing the code examples.