### PR TITLE
Java SDK: Create R2L scenario performance test definitions

### DIFF
--- a/android/services/mongodb-remote-perftests/build.gradle
+++ b/android/services/mongodb-remote-perftests/build.gradle
@@ -41,7 +41,8 @@ android {
                 "test.stitch.perf.outputStdout",
                 "test.stitch.perf.outputStitch",
                 "test.stitch.perf.rawOutput",
-                "test.stitch.perf.changeEventPercentages"
+                "test.stitch.perf.changeEventPercentages",
+                "test.stitch.perf.conflictPercentages"
         ]
 
         for (final String propertyName : propertyNames) {

--- a/android/services/mongodb-remote-perftests/build.gradle
+++ b/android/services/mongodb-remote-perftests/build.gradle
@@ -40,7 +40,8 @@ android {
                 "test.stitch.perf.outliers",
                 "test.stitch.perf.outputStdout",
                 "test.stitch.perf.outputStitch",
-                "test.stitch.perf.rawOutput"
+                "test.stitch.perf.rawOutput",
+                "test.stitch.perf.changeEventPercentages"
         ]
 
         for (final String propertyName : propertyNames) {

--- a/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncL2ROnlyPerformanceTestDefinitions.kt
+++ b/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncL2ROnlyPerformanceTestDefinitions.kt
@@ -10,7 +10,7 @@ class SyncL2ROnlyPerformanceTestDefinitions {
     companion object {
 
         fun testInitialSync(testHarness: SyncPerformanceIntTestsHarness, runId: ObjectId) {
-            val testName = "testL2R_InitialSync"
+            val testName = "L2R_InitialSync"
 
             // Local variable for list of documents captured by the test definition closures below.
             // This should change for each iteration of the test.
@@ -58,7 +58,7 @@ class SyncL2ROnlyPerformanceTestDefinitions {
         }
 
         fun testDisconnectReconnect(testHarness: SyncPerformanceIntTestsHarness, runId: ObjectId) {
-            val testName = "testL2R_DisconnectReconnect"
+            val testName = "L2R_DisconnectReconnect"
 
             testHarness.runPerformanceTestWithParams(
                     testName, runId,
@@ -145,7 +145,7 @@ class SyncL2ROnlyPerformanceTestDefinitions {
             runId: ObjectId,
             pctOfDocsWithChangeEvents: Double
         ) {
-            val testName = "testL2R_SyncPass_${pctOfDocsWithChangeEvents}DocsChanged"
+            val testName = "L2R_SyncPass_${(pctOfDocsWithChangeEvents * 100).toInt()}_DocsChanged"
 
             // Local variable for the number of docs updated in the test
             // This should change for each iteration of the test.

--- a/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncL2ROnlyPerformanceTestDefinitions.kt
+++ b/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncL2ROnlyPerformanceTestDefinitions.kt
@@ -52,7 +52,7 @@ class SyncL2ROnlyPerformanceTestDefinitions {
                     },
                     afterEach = { ctx, numDocs, _ ->
                         // Verify that the test did indeed synchronize the updates remotely
-                        SyncPerformanceTestUtils.asertLocalAndRemoteDBCount(ctx, numDocs)
+                        SyncPerformanceTestUtils.assertLocalAndRemoteDBCount(ctx, numDocs)
                     }
             )
         }
@@ -128,7 +128,7 @@ class SyncL2ROnlyPerformanceTestDefinitions {
                     },
                     afterEach = { ctx, numDocs: Int, _ ->
                         // Verify that the test did indeed synchronize the updates remotely
-                        SyncPerformanceTestUtils.asertLocalAndRemoteDBCount(ctx, numDocs)
+                        SyncPerformanceTestUtils.assertLocalAndRemoteDBCount(ctx, numDocs)
                     }
             )
         }
@@ -227,7 +227,7 @@ class SyncL2ROnlyPerformanceTestDefinitions {
                     },
                     afterEach = { ctx, numDocs: Int, _ ->
                         // Verify that the test did indeed synchronize the updates remotely
-                        SyncPerformanceTestUtils.asertLocalAndRemoteDBCount(ctx, numDocs)
+                        SyncPerformanceTestUtils.assertLocalAndRemoteDBCount(ctx, numDocs)
 
                         // Verify that the test did indeed synchronize the provided documents
                         // remotely, and that the documents that were supposed to be updated got

--- a/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncL2ROnlyPerformanceTestDefinitions.kt
+++ b/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncL2ROnlyPerformanceTestDefinitions.kt
@@ -188,9 +188,8 @@ class SyncL2ROnlyPerformanceTestDefinitions {
                         val ids = shuffledDocs.map { BsonObjectId(it.getObjectId("_id")) }
 
                         // Perform the local update and ensure it worked properly
-                        numberOfChangedDocs = SyncPerformanceTestUtils.performLocalUpdate(
-                            ctx, ids, numDocs, pctOfDocsWithChangeEvents
-                        )
+                        val numChange = (numDocs * pctOfDocsWithChangeEvents).toInt()
+                        SyncPerformanceTestUtils.performLocalUpdate(ctx, ids.subList(0, numChange))
                     },
                     testDefinition = { ctx, _, _ ->
                         // Do the sync pass that will sync the

--- a/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncL2ROnlyPerformanceTestDefinitions.kt
+++ b/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncL2ROnlyPerformanceTestDefinitions.kt
@@ -184,9 +184,6 @@ class SyncL2ROnlyPerformanceTestDefinitions {
                         // Randomly sample a percentage of the documents
                         // that will be locally updated
                         val shuffledDocs = documentsForCurrentTest.shuffled()
-
-                        // Randomly sample a percentage of the documents
-                        // that will be locally updated
                         val numDocsChanged = Math.round(pctOfDocsWithChangeEvents*numDocs).toInt()
                         val docsToUpdate =
                             if (pctOfDocsWithChangeEvents > 0.0)
@@ -200,17 +197,23 @@ class SyncL2ROnlyPerformanceTestDefinitions {
                         ))
 
                         // Assert that the update worked
-                        SyncPerformanceTestUtils.assertIntsAreEqualOrThrow(updateResult.matchedCount.toInt(), numDocsChanged,
+                        SyncPerformanceTestUtils.assertIntsAreEqualOrThrow(
+                            updateResult.matchedCount.toInt(),
+                            numDocsChanged,
                             "RemoteUpdateResult.matchedCount"
                         )
-                        SyncPerformanceTestUtils.assertIntsAreEqualOrThrow(updateResult.modifiedCount.toInt(), numDocsChanged,
+                        SyncPerformanceTestUtils.assertIntsAreEqualOrThrow(
+                            updateResult.modifiedCount.toInt(),
+                            numDocsChanged,
                             "RemoteUpdateResult.modifiedCount"
                         )
                         val numDocsChangedLocally = Tasks.await(sync.count(
                             Document("newField", Document("\$exists", true))
                         ))
                         SyncPerformanceTestUtils.assertIntsAreEqualOrThrow(
-                            numDocsChanged, numDocsChangedLocally.toInt(), "Local document updates"
+                            numDocsChanged,
+                            numDocsChangedLocally.toInt(),
+                            "Local document updates"
                         )
 
                         numberOfChangedDocs = numDocsChanged

--- a/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncL2ROnlyPerformanceTestDefinitions.kt
+++ b/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncL2ROnlyPerformanceTestDefinitions.kt
@@ -210,7 +210,7 @@ class SyncL2ROnlyPerformanceTestDefinitions {
                             Document("newField", Document("\$exists", true))
                         ))
                         SyncPerformanceTestUtils.assertIntsAreEqualOrThrow(
-                            numberOfChangedDocs, numDocsChangedLocally.toInt(), "Remote document updates"
+                            numberOfChangedDocs, numDocsChangedLocally.toInt(), "Local document updates"
                         )
                     },
                     testDefinition = { ctx, _, _ ->

--- a/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncL2ROnlyPerformanceTestDefinitions.kt
+++ b/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncL2ROnlyPerformanceTestDefinitions.kt
@@ -190,6 +190,7 @@ class SyncL2ROnlyPerformanceTestDefinitions {
                         // Perform the local update and ensure it worked properly
                         val numChange = (numDocs * pctOfDocsWithChangeEvents).toInt()
                         SyncPerformanceTestUtils.performLocalUpdate(ctx, ids.subList(0, numChange))
+                        numberOfChangedDocs = numChange
                     },
                     testDefinition = { ctx, _, _ ->
                         // Do the sync pass that will sync the

--- a/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncPerformanceIntTestsHarness.kt
+++ b/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncPerformanceIntTestsHarness.kt
@@ -174,6 +174,7 @@ class SyncPerformanceIntTestsHarness : BaseStitchAndroidIntTest() {
                 val runResult = RunResult(numDoc, docSize)
 
                 for (iter in 1..SyncPerformanceTestUtils.getNumIters()) {
+                    logMessage("Testing (docSize: $docSize, numDocs: $numDoc, iter: $iter)")
                     var ctx = createPerformanceTestingContext(testName)
                     try {
                         ctx.setup()
@@ -189,8 +190,13 @@ class SyncPerformanceIntTestsHarness : BaseStitchAndroidIntTest() {
 
                         afterEach(ctx, numDoc, docSize)
                     } catch (e: Exception) {
-                        runResult.failures.add(FailureResult(iter, e.localizedMessage,
+                        var failureMessage = e.toString()
+                        if (e.localizedMessage != null) {
+                            failureMessage = e.localizedMessage
+                        }
+                        runResult.failures.add(FailureResult(iter, failureMessage,
                             e.stackTrace.map { BsonString(it.toString()) }))
+                        logMessage("Failure: $failureMessage")
                     } finally {
                         ctx.teardown()
                     }

--- a/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncPerformanceIntTestsHarness.kt
+++ b/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncPerformanceIntTestsHarness.kt
@@ -190,10 +190,7 @@ class SyncPerformanceIntTestsHarness : BaseStitchAndroidIntTest() {
 
                         afterEach(ctx, numDoc, docSize)
                     } catch (e: Exception) {
-                        var failureMessage = e.toString()
-                        if (e.localizedMessage != null) {
-                            failureMessage = e.localizedMessage
-                        }
+                        val failureMessage = e.localizedMessage ?: e.toString()
                         runResult.failures.add(FailureResult(iter, failureMessage,
                             e.stackTrace.map { BsonString(it.toString()) }))
                         logMessage("Failure: $failureMessage")

--- a/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncPerformanceTestContext.kt
+++ b/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncPerformanceTestContext.kt
@@ -16,7 +16,7 @@ import java.util.Date
 import org.bson.Document
 import org.bson.types.ObjectId
 
-open abstract class SyncPerformanceTestContext(
+abstract class SyncPerformanceTestContext(
     private val harness: SyncPerformanceIntTestsHarness,
     private val testName: String
 ) {

--- a/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncPerformanceTestUtils.kt
+++ b/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncPerformanceTestUtils.kt
@@ -106,7 +106,7 @@ class SyncPerformanceTestUtils {
                 preserveRawOutputProp, defaultPreserveRawOutput)!!.toBoolean()
         }
 
-        internal fun asertLocalAndRemoteDBCount(ctx: SyncPerformanceTestContext, numDocs: Int) {
+        internal fun assertLocalAndRemoteDBCount(ctx: SyncPerformanceTestContext, numDocs: Int) {
             // Verify that the test did indeed synchronize the updates remotely
             val numSyncedIds = Tasks.await(ctx.testColl.sync().syncedIds).size
             val numLocalDocs = Tasks.await(ctx.testColl.sync().count()).toInt()

--- a/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncPerformanceTestUtils.kt
+++ b/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncPerformanceTestUtils.kt
@@ -47,6 +47,9 @@ class SyncPerformanceTestUtils {
         private const val changeEventPercentagesProp = "test.stitch.perf.changeEventPercentages"
         private const val defaultChangeEventPercentages = "0.0,0.01,0.10,0.25,0.50,1.0"
 
+        private const val conflictPercentagesProp = "test.stitch.perf.conflictPercentages"
+        private const val defaultConflictPercentagesProp = "0.1,0.5,1.0"
+
         internal fun getStitchHostname(): String {
             return InstrumentationRegistry.getArguments().getString(
                     stitchHostnameProp, defaultStitchHostname
@@ -91,6 +94,12 @@ class SyncPerformanceTestUtils {
                 .split(",").map { it.toDouble() }.toDoubleArray()
         }
 
+        internal fun getConflictPercentages(): DoubleArray {
+            return InstrumentationRegistry.getArguments()
+                .getString(conflictPercentagesProp, defaultConflictPercentagesProp)
+                .split(",").map { it.toDouble() }.toDoubleArray()
+        }
+
         internal fun shouldOutputToStdOut(): Boolean {
             return InstrumentationRegistry.getArguments().getString(
                 outputToStdOutProp, defaultOutputToStdOut)!!.toBoolean()
@@ -124,17 +133,18 @@ class SyncPerformanceTestUtils {
             if (expected == actual) {
                 return
             }
-            throw Exception(String.format("Expected: %s but found %s: %s", expected, actual, message))
+            throw PerformanceTestingException(
+                String.format("Expected: %s but found %s: %s", expected, actual, message))
         }
 
         internal fun doSyncPass(ctx: SyncPerformanceTestContext): Boolean {
             ctx.testNetworkMonitor.connectedState = true
             var counter = 0
             while (!ctx.testDataSynchronizer.areAllStreamsOpen()) {
-                Thread.sleep(5)
+                Thread.sleep(30)
                 // if this hangs longer than 30 seconds, throw an error
                 counter += 1
-                if (counter > 500) {
+                if (counter > 1000) {
                     Log.e("perfTests", "stream never opened after reconnect")
                     error("stream never opened after reconnect")
                 }

--- a/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncR2LOnlyPerformanceTestDefinitions.kt
+++ b/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncR2LOnlyPerformanceTestDefinitions.kt
@@ -1,0 +1,266 @@
+package com.mongodb.stitch.android.services.mongodb.performance
+
+import com.google.android.gms.tasks.Tasks
+import com.mongodb.stitch.android.services.mongodb.performance.SyncPerformanceTestUtils.Companion.assertIntsAreEqualOrThrow
+import com.mongodb.stitch.core.services.mongodb.remote.ExceptionListener
+import com.mongodb.stitch.core.services.mongodb.remote.sync.DefaultSyncConflictResolvers
+import org.bson.BsonValue
+import org.bson.Document
+import org.bson.types.ObjectId
+
+class SyncR2LOnlyPerformanceTestDefinitions {
+    companion object {
+
+        fun testInitialSync(testHarness: SyncPerformanceIntTestsHarness, runId: ObjectId) {
+            val testName = "R2L_InitialSync"
+
+            // Local variable for list of documents captured by the test definition closures below.
+            // This should change for each iteration of the test.
+            var documentIdsForCurrentTest: List<BsonValue?>? = null
+
+            // Initial sync for a purely R2L Scenario means inserting remote documents and then
+            // configuring syncMany() on the inserted document id's and performing a sync pass.
+            testHarness.runPerformanceTestWithParams(
+                testName, runId,
+                beforeEach = { ctx, numDocs, docSize ->
+                    // Generate the documents that are to be synced via R2L and remotely insert them
+                    documentIdsForCurrentTest = SyncPerformanceTestUtils.insertToRemote(
+                        ctx, numDocs, docSize
+                    )
+                },
+                testDefinition = { ctx, _, _ ->
+                    val sync = ctx.testColl.sync()
+
+                    // If sync fails for any reason, halt the test
+                    Tasks.await(sync.configure(
+                        DefaultSyncConflictResolvers.remoteWins(),
+                        null,
+                        ExceptionListener { id, ex ->
+                            testHarness.logMessage("unexpected sync error with id " +
+                                "$id: ${ex.localizedMessage}")
+                            error(ex)
+                        }
+                    ))
+
+                    // Sync() on all of the inserted document ids
+                    Tasks.await(sync.syncMany(*(documentIdsForCurrentTest!!.toTypedArray())))
+
+                    // Perform syncPass() and halt the test if the pass fails
+                    if (!SyncPerformanceTestUtils.doSyncPass(ctx)) {
+                        error("sync pass failed")
+                    }
+                },
+                afterEach = { ctx, numDocs, _ ->
+                    // Verify that the test did indeed synchronize the provided documents locally
+                    SyncPerformanceTestUtils.asertLocalAndRemoteDBCount(ctx, numDocs)
+                }
+            )
+        }
+
+        fun testDisconnectReconnect(testHarness: SyncPerformanceIntTestsHarness, runId: ObjectId) {
+            val testName = "R2L_DisconnectReconnect"
+
+            // Local variable for list of documents captured by the test definition closures below.
+            // This should change for each iteration of the test.
+            var documentIdsForCurrentTest: List<BsonValue?>? = null
+
+            testHarness.runPerformanceTestWithParams(
+                testName, runId,
+                beforeEach = { ctx, numDocs, docSize ->
+                    val sync = ctx.testColl.sync()
+
+                    // Generate the documents that are to be synced via R2L and insert remotely
+                    val ids = SyncPerformanceTestUtils.insertToRemote(
+                        ctx, numDocs, docSize
+                    )
+
+                    // If sync fails for any reason, halt the test
+                    Tasks.await(sync.configure(
+                        DefaultSyncConflictResolvers.remoteWins(),
+                        null,
+                        ExceptionListener { id, ex ->
+                            testHarness.logMessage("unexpected sync error with id " +
+                                "$id: ${ex.localizedMessage}")
+                            error(ex)
+                        }
+                    ))
+
+                    // Sync() on all of the inserted document ids
+                    Tasks.await(sync.syncMany(*(ids!!.toTypedArray())))
+
+                    // Halt the test if the sync pass failed
+                    if (!SyncPerformanceTestUtils.doSyncPass(ctx)) {
+                        error("sync pass failed")
+                    }
+
+                    // Verify that the test did indeed synchronize the provided documents locally
+                    val numSyncedIds = Tasks.await(sync.syncedIds).size
+                    val numLocalDocs = Tasks.await(sync.count())
+
+                    SyncPerformanceTestUtils.assertIntsAreEqualOrThrow(
+                        numSyncedIds, numDocs, "Number of Synced Ids")
+                    SyncPerformanceTestUtils.assertIntsAreEqualOrThrow(
+                        numLocalDocs.toInt(), numDocs, "Number of Local Documents")
+
+                    // Disconnect the DataSynchronizer and wait
+                    // for the underlying streams to close
+                    ctx.testNetworkMonitor.connectedState = false
+                    while (ctx.testDataSynchronizer.areAllStreamsOpen()) {
+                        testHarness.logMessage("waiting for streams to close")
+                        Thread.sleep(1000)
+                    }
+                },
+                testDefinition = { ctx, _, _ ->
+                    // Reconnect the DataSynchronizer, and wait for the streams to reopen. The
+                    // stream being open indicates that the doc configs are now set as stale.
+                    // Check every 10ms so we're not doing too much work on this thread, and
+                    // don't log anything, so as not to pollute the test results with logging
+                    // overhead.
+                    ctx.testNetworkMonitor.connectedState = true
+                    var counter = 0
+                    while (!ctx.testDataSynchronizer.areAllStreamsOpen()) {
+                        Thread.sleep(10)
+
+                        // if this hangs longer than 30 seconds, throw an error
+                        counter += 1
+                        if (counter > 3000) {
+                            testHarness.logMessage("stream never opened after reconnect")
+                            error("stream never opened after reconnect")
+                        }
+                    }
+
+                    // Do the sync pass that will perform the stale document fetch
+                    val syncPassSucceeded = ctx.testDataSynchronizer.doSyncPass()
+
+                    // Perform syncPass() and halt the test if the pass fails
+                    if (!syncPassSucceeded) {
+                        error("sync pass failed")
+                    }
+                },
+                afterEach = { ctx, numDocs, _ ->
+                    // Verify that the test did indeed synchronize the updates locally
+                    SyncPerformanceTestUtils.asertLocalAndRemoteDBCount(ctx, numDocs)
+                }
+            )
+        }
+
+        fun testSyncPass(testHarness: SyncPerformanceIntTestsHarness, runId: ObjectId) {
+            // Run doTestSyncPass() for all changeEvent Percentages found in SyncPerfTestUtils
+            SyncPerformanceTestUtils.getChangeEventPercentages().forEach {
+                doTestSyncPass(testHarness, runId, it)
+            }
+        }
+
+        private fun doTestSyncPass(
+            testHarness: SyncPerformanceIntTestsHarness,
+            runId: ObjectId,
+            pctOfDocsWithChangeEvents: Double
+        ) {
+            val testName = "testR2L_SyncPass_${pctOfDocsWithChangeEvents}_PctDocsChanged"
+
+            // Local variable for the number of docs updated in the test
+            // This should change for each iteration of the test.
+            var numberOfChangedDocs = -1
+
+            testHarness.runPerformanceTestWithParams(
+                testName, runId,
+                beforeEach = { ctx, numDocs: Int, docSize: Int ->
+                    val sync = ctx.testColl.sync()
+
+                    // Generate the documents that are to be synced via R2L and insert remotely
+                    val ids = SyncPerformanceTestUtils.insertToRemote(
+                        ctx, numDocs, docSize
+                    )
+
+                    // If sync fails for any reason, halt the test
+                    Tasks.await(ctx.testColl.sync().configure(
+                        DefaultSyncConflictResolvers.remoteWins(),
+                        null,
+                        ExceptionListener { id, ex ->
+                            testHarness.logMessage(
+                                "unexpected sync error with id " +
+                                "$id: ${ex.localizedMessage}")
+                            error(ex)
+                        }
+                    ))
+
+                    // Sync on the ids inserted remotely
+                    Tasks.await(sync.syncMany(*(ids!!.toTypedArray())))
+
+                    // Halt the test if the sync pass failed
+                    if (!SyncPerformanceTestUtils.doSyncPass(ctx)) {
+                        error("sync pass failed")
+                    }
+
+                    // Verify that the test did indeed synchronize the provided documents locally
+                    val numSyncedIds = Tasks.await(sync.syncedIds).size
+                    val numLocalDocs = Tasks.await(sync.count())
+
+                    SyncPerformanceTestUtils.assertIntsAreEqualOrThrow(
+                        numSyncedIds, numDocs, "Number of Synced Ids")
+                    SyncPerformanceTestUtils.assertIntsAreEqualOrThrow(
+                        numLocalDocs.toInt(), numDocs, "Number of Local Documents")
+
+                    // Disconnect the DataSynchronizer and wait
+                    // for the underlying streams to close
+                    ctx.testNetworkMonitor.connectedState = false
+                    while (ctx.testDataSynchronizer.areAllStreamsOpen()) {
+                        testHarness.logMessage("waiting for streams to close")
+                        Thread.sleep(1000)
+                    }
+
+                    // Randomly sample a percentage of the documents
+                    // that will be locally updated
+                    val shuffledDocIds = ids.shuffled()
+                    numberOfChangedDocs = Math.round(pctOfDocsWithChangeEvents*numDocs).toInt()
+                    val docsToUpdate =
+                        if (pctOfDocsWithChangeEvents > 0.0)
+                            shuffledDocIds.subList(0, numberOfChangedDocs)
+                        else
+                            emptyList()
+
+                    val updateResult = Tasks.await(ctx.testColl.updateMany(
+                        Document("_id", Document("\$in", docsToUpdate)),
+                        Document("\$set", Document("newField", "blah"))
+                    ))
+
+                    // Assert that the update worked
+                    assertIntsAreEqualOrThrow(updateResult.matchedCount.toInt(), numberOfChangedDocs,
+                        "RemoteUpdateResult.matchedCount")
+                    assertIntsAreEqualOrThrow(updateResult.modifiedCount.toInt(), numberOfChangedDocs,
+                        "RemoteUpdateResult.modifiedCount")
+
+                    val numDocsChangedRemotely = Tasks.await(ctx.testColl.count(
+                        Document("newField", Document("\$exists", true))
+                    ))
+                    SyncPerformanceTestUtils.assertIntsAreEqualOrThrow(
+                        numberOfChangedDocs, numDocsChangedRemotely.toInt(), "Remote document updates"
+                    )
+                },
+                testDefinition = { ctx, _, _ ->
+                    // Do the sync pass that will sync the remote changes to the local collection
+                    // Perform syncPass() and halt the test if the pass fails
+                    if (!SyncPerformanceTestUtils.doSyncPass(ctx)) {
+                        error("sync pass failed")
+                    }
+
+                    if (!SyncPerformanceTestUtils.doSyncPass(ctx)) {
+                        error("sync pass failed")
+                    }
+                },
+                afterEach = { ctx, numDocs: Int, _ ->
+                    // Verify that the test did indeed synchronize the updates locally
+                    SyncPerformanceTestUtils.asertLocalAndRemoteDBCount(ctx, numDocs)
+
+                    // Verify the updates were applied locally
+                    val numDocsChangedLocally = Tasks.await(ctx.testColl.sync().count(
+                        Document("newField", Document("\$exists", true))
+                    )).toInt()
+                    SyncPerformanceTestUtils.assertIntsAreEqualOrThrow(
+                        numDocsChangedLocally, numberOfChangedDocs, "Local document updates"
+                    )
+                }
+            )
+        }
+    }
+}

--- a/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncR2LOnlyPerformanceTestDefinitions.kt
+++ b/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncR2LOnlyPerformanceTestDefinitions.kt
@@ -52,7 +52,7 @@ class SyncR2LOnlyPerformanceTestDefinitions {
                 },
                 afterEach = { ctx, numDocs, _ ->
                     // Verify that the test did indeed synchronize the provided documents locally
-                    SyncPerformanceTestUtils.asertLocalAndRemoteDBCount(ctx, numDocs)
+                    SyncPerformanceTestUtils.assertLocalAndRemoteDBCount(ctx, numDocs)
                 }
             )
         }
@@ -139,7 +139,7 @@ class SyncR2LOnlyPerformanceTestDefinitions {
                 },
                 afterEach = { ctx, numDocs, _ ->
                     // Verify that the test did indeed synchronize the updates locally
-                    SyncPerformanceTestUtils.asertLocalAndRemoteDBCount(ctx, numDocs)
+                    SyncPerformanceTestUtils.assertLocalAndRemoteDBCount(ctx, numDocs)
                 }
             )
         }
@@ -252,7 +252,7 @@ class SyncR2LOnlyPerformanceTestDefinitions {
                 },
                 afterEach = { ctx, numDocs: Int, _ ->
                     // Verify that the test did indeed synchronize the updates locally
-                    SyncPerformanceTestUtils.asertLocalAndRemoteDBCount(ctx, numDocs)
+                    SyncPerformanceTestUtils.assertLocalAndRemoteDBCount(ctx, numDocs)
 
                     // Verify the updates were applied locally
                     val numChangedDocs = numberOfChangedDocs ?: -1

--- a/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncR2LOnlyPerformanceTestDefinitions.kt
+++ b/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncR2LOnlyPerformanceTestDefinitions.kt
@@ -201,7 +201,7 @@ class SyncR2LOnlyPerformanceTestDefinitions {
                     // Remotely update the desired percentage of documents and check it works
                     var numChange = (pctOfDocsWithChangeEvents * numDocs).toInt()
                     SyncPerformanceTestUtils.performRemoteUpdate(ctx, ids.subList(0, numChange))
-                    numberOfChangedDocs = numDocs
+                    numberOfChangedDocs = numChange
 
                     // Locally update the desired percentage of documents and check it works
                     numChange = (pctOfDocsWithChangeEvents * pctOfDocsWithConflicts * numDocs).toInt()

--- a/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncR2LOnlyPerformanceTestDefinitions.kt
+++ b/android/services/mongodb-remote-perftests/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/performance/SyncR2LOnlyPerformanceTestDefinitions.kt
@@ -161,7 +161,7 @@ class SyncR2LOnlyPerformanceTestDefinitions {
             pctOfDocsWithChangeEvents: Double,
             pctOfDocsWithConflicts: Double
         ) {
-            val testName = "testR2L_SyncPass_${(pctOfDocsWithChangeEvents * 100).toInt()}" +
+            val testName = "R2L_SyncPass_${(pctOfDocsWithChangeEvents * 100).toInt()}" +
                 "_PctDocsChanged_${(pctOfDocsWithConflicts * 100).toInt()}_PctDocsConflicts"
 
             // Local variable for the number of docs updated in the test
@@ -183,7 +183,7 @@ class SyncR2LOnlyPerformanceTestDefinitions {
 
                     // If sync fails for any reason, halt the test
                     Tasks.await(ctx.testColl.sync().configure(
-                        DefaultSyncConflictResolvers.localWins(),
+                        DefaultSyncConflictResolvers.remoteWins(),
                         null,
                         ExceptionListener { id, ex ->
                             testHarness.logMessage(
@@ -230,7 +230,6 @@ class SyncR2LOnlyPerformanceTestDefinitions {
 
                     // Verify the updates were applied locally
                     val numRemoteUpdates = numberOfChangedDocs ?: -1
-                    val numLocalUpdates =  numberOfConflicts ?: -1
 
                     // Both the local and remote should have
                     //      numRemoteUpdates documents with {newField: "remote"}
@@ -251,7 +250,8 @@ class SyncR2LOnlyPerformanceTestDefinitions {
             ctx: SyncPerformanceTestContext,
             ids: List<BsonValue>,
             numDocs: Int,
-            percentage: Double): Int {
+            percentage: Double
+        ): Int {
 
             val numChangedDocs = Math.round(percentage*numDocs).toInt()
             val docsToUpdate = ids.subList(0, numChangedDocs)
@@ -288,7 +288,8 @@ class SyncR2LOnlyPerformanceTestDefinitions {
             ctx: SyncPerformanceTestContext,
             ids: List<BsonValue>,
             numDocs: Int,
-            percentage: Double): Int {
+            percentage: Double
+        ): Int {
 
             val numChangedDocs = Math.round(percentage*numDocs).toInt()
             val docsToUpdate = ids.subList(0, numChangedDocs)

--- a/android/services/mongodb-remote-perftests/src/main/java/com/mongodb/stitch/android/services/mongodb/performance/OkHttpInstrumentedTransport.kt
+++ b/android/services/mongodb-remote-perftests/src/main/java/com/mongodb/stitch/android/services/mongodb/performance/OkHttpInstrumentedTransport.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.stitch.android.services.mongodb.performance
 
 import com.mongodb.stitch.core.internal.net.OkHttpTransport

--- a/android/services/mongodb-remote-perftests/src/main/java/com/mongodb/stitch/android/services/mongodb/performance/PerformanceTestingException.java
+++ b/android/services/mongodb-remote-perftests/src/main/java/com/mongodb/stitch/android/services/mongodb/performance/PerformanceTestingException.java
@@ -1,0 +1,11 @@
+package com.mongodb.stitch.android.services.mongodb.performance;
+
+/**
+ * Exception pertaining to any errors related to the
+ * Performance Testing module.
+ */
+class PerformanceTestingException extends Exception {
+  PerformanceTestingException(final String msg) {
+    super(msg);
+  }
+}

--- a/android/services/mongodb-remote-perftests/src/main/java/com/mongodb/stitch/android/services/mongodb/performance/PerformanceTestingException.java
+++ b/android/services/mongodb-remote-perftests/src/main/java/com/mongodb/stitch/android/services/mongodb/performance/PerformanceTestingException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.stitch.android.services.mongodb.performance;
 
 /**

--- a/core/sdk/src/main/java/com/mongodb/stitch/core/StitchRequestErrorCode.java
+++ b/core/sdk/src/main/java/com/mongodb/stitch/core/StitchRequestErrorCode.java
@@ -18,6 +18,7 @@ package com.mongodb.stitch.core;
 
 /** StitchRequestErrorCode represents the reasons that a request may fail. */
 public enum StitchRequestErrorCode {
+  REQUEST_SIZE_ERROR("the request was too large to be processed by Stitch"),
   TRANSPORT_ERROR("the request transport encountered an error communicating with Stitch"),
   DECODING_ERROR("an error occurred while decoding a response from Stitch"),
   ENCODING_ERROR("an error occurred while encoding a request for Stitch"),

--- a/core/sdk/src/main/java/com/mongodb/stitch/core/internal/net/OkHttpTransport.java
+++ b/core/sdk/src/main/java/com/mongodb/stitch/core/internal/net/OkHttpTransport.java
@@ -16,6 +16,8 @@
 
 package com.mongodb.stitch.core.internal.net;
 
+import com.mongodb.stitch.core.StitchRequestErrorCode;
+import com.mongodb.stitch.core.StitchRequestException;
 import com.mongodb.stitch.core.internal.common.StitchError;
 
 import java.io.IOException;
@@ -105,6 +107,10 @@ public class OkHttpTransport implements Transport {
   @Override
   // This executes a request synchronously
   public Response roundTrip(final Request request) throws IOException {
+    if (request.getBody() != null && request.getBody().length >= MAX_REQUEST_SIZE) {
+      throw new StitchRequestException(String.format("body was %d bytes", request.getBody().length),
+        StitchRequestErrorCode.REQUEST_SIZE_ERROR);
+    }
     final OkHttpClient reqClient = newClientBuilder(
         request.getTimeout(), request.getTimeout(), request.getTimeout()
     ).build();

--- a/core/sdk/src/main/java/com/mongodb/stitch/core/internal/net/Transport.java
+++ b/core/sdk/src/main/java/com/mongodb/stitch/core/internal/net/Transport.java
@@ -19,6 +19,8 @@ package com.mongodb.stitch.core.internal.net;
 import java.io.IOException;
 
 public interface Transport {
+  // This is how Stitch Server calculates the maximum request size
+  // This number is equal to 4,194,304 or ~ 4Mb
   int MAX_REQUEST_SIZE = 1 << 22;
 
   Response roundTrip(Request request) throws Exception;

--- a/core/sdk/src/main/java/com/mongodb/stitch/core/internal/net/Transport.java
+++ b/core/sdk/src/main/java/com/mongodb/stitch/core/internal/net/Transport.java
@@ -19,6 +19,8 @@ package com.mongodb.stitch.core.internal.net;
 import java.io.IOException;
 
 public interface Transport {
+  int MAX_REQUEST_SIZE = 1 << 22;
+
   Response roundTrip(Request request) throws Exception;
 
   EventStream stream(Request request) throws IOException;


### PR DESCRIPTION
This pull request accomplishes the following: 
1. Defines the Remote To Local performance tests (intiailSync, disconnectReconnect, syncPass)
2. Adds changeEventPercentages as configurable option in evergreen / local.properties
3. Puts some utility functions in SyncPerformanceTestutils.kt
4. Makes some small changes to the L2R tests 
5. Drive-by fix for not sending out requests that are too large for stitch to handle
