### PR TITLE
STITCH-2806 - Fix hash calculation to use unsigned bytes

### DIFF
--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/HashUtils.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/HashUtils.java
@@ -51,7 +51,7 @@ public final class HashUtils {
     long hashValue = FNV_64BIT_OFFSET_BASIS;
 
     for (int offset = 0; offset < docBytes.length; offset++) {
-      hashValue ^= docBytes[offset];
+      hashValue ^= (0xFF & docBytes[offset]);
       hashValue *= FNV_64BIT_PRIME;
     }
 

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/HashUtilsUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/HashUtilsUnitTests.kt
@@ -1,7 +1,12 @@
 package com.mongodb.stitch.core.services.mongodb.remote.sync.internal
 
+import org.bson.BsonArray
+import org.bson.BsonBoolean
 import org.bson.BsonDocument
+import org.bson.BsonInt32
+import org.bson.BsonObjectId
 import org.bson.BsonString
+import org.bson.types.ObjectId
 import org.junit.Assert
 import org.junit.Test
 
@@ -9,6 +14,9 @@ class HashUtilsUnitTests {
     companion object {
         const val TEST_EMPTY_BSON_DOC_HASH = -6534195273556634272L
         const val TEST_HELLO_WORLD_BSON_DOC_HASH = 3488831889965352219L
+        const val TEST_NESTED_BSON_DOC_HASH = 2637880642529775697L
+
+        val BSON_OBJECT_ID = ObjectId("5cb8a847a8d14019f59b99f0")
     }
 
     @Test
@@ -20,5 +28,24 @@ class HashUtilsUnitTests {
     fun testHashFunctionHashesHelloWorldBsonDocumentCorrectly() {
         Assert.assertEquals(TEST_HELLO_WORLD_BSON_DOC_HASH,
                 HashUtils.hash(BsonDocument("hello", BsonString("world"))))
+    }
+
+    @Test
+    fun testHashFunctionHashesNestedBsonDocumentCorrectly() {
+        Assert.assertEquals(TEST_NESTED_BSON_DOC_HASH,
+                HashUtils.hash(BsonDocument()
+                        .append("_id", BsonObjectId(BSON_OBJECT_ID))
+                        .append("foo", BsonDocument()
+                                .append("hello", BsonString("world"))
+                                .append("ways to leave",
+                                        BsonArray(listOf(
+                                                    BsonString("make a new plan, Stan"),
+                                                    BsonString("sneak out the back, Jack"),
+                                                    BsonString("no need to be coy, Roy"),
+                                                    BsonString("just hop on the bus, Gus"),
+                                                    BsonString("drop off the key, Lee")))))
+                        .append("bar", BsonInt32(42))
+                        .append("baz", BsonString("metasyntactic variables rule"))
+                        .append("quux", BsonBoolean(true))))
     }
 }


### PR DESCRIPTION
Changes hash calculation to use unsigned bytes so as to be conformant with Go and Swift