### PR TITLE
STITCH-2847: Investigate document availability using sync.find() when change event is received

### DIFF
--- a/android/services/mongodb-remote/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/remote/internal/SyncMongoClientIntTests.kt
+++ b/android/services/mongodb-remote/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/remote/internal/SyncMongoClientIntTests.kt
@@ -465,6 +465,11 @@ class SyncMongoClientIntTests : BaseStitchAndroidIntTest(), SyncIntTestRunner {
         testProxy.testUpdateSyncFrequency()
     }
 
+    @Test
+    override fun testFindOnReceivingChangeEvent() {
+        testProxy.testFindOnReceivingChangeEvent()
+    }
+
     /**
      * Get the uri for where mongodb is running locally.
      */

--- a/android/services/mongodb-remote/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/remote/internal/SyncMongoClientIntTests.kt
+++ b/android/services/mongodb-remote/src/androidTest/java/com/mongodb/stitch/android/services/mongodb/remote/internal/SyncMongoClientIntTests.kt
@@ -79,8 +79,23 @@ class SyncMongoClientIntTests : BaseStitchAndroidIntTest(), SyncIntTestRunner {
                 sync.configure(
                     conflictResolver,
                     changeEventListener,
+                    exceptionListener
+                )
+            )
+        }
+
+        override fun configure(
+            conflictResolver: ConflictHandler<Document?>,
+            changeEventListener: ChangeEventListener<Document>?,
+            exceptionListener: ExceptionListener?,
+            syncFrequency: SyncFrequency?
+        ): Void? {
+            return Tasks.await(
+                sync.configure(
+                    conflictResolver,
+                    changeEventListener,
                     exceptionListener,
-                    SyncFrequency.reactive()
+                    syncFrequency
                 )
             )
         }

--- a/android/services/mongodb-remote/src/main/java/com/mongodb/stitch/android/services/mongodb/remote/Sync.java
+++ b/android/services/mongodb-remote/src/main/java/com/mongodb/stitch/android/services/mongodb/remote/Sync.java
@@ -56,6 +56,26 @@ public interface Sync<DocumentT> {
    * @param changeEventListener the event listener to invoke when a change event happens for the
    *                         document.
    * @param exceptionListener the error listener to invoke when an irrecoverable error occurs
+   *
+   * @return A Task that completes when Mobile Sync is configured, and the background sync thread
+   *         has started.
+   */
+  @Deprecated
+  @CheckReturnValue
+  Task<Void> configure(@NonNull final ConflictHandler<DocumentT> conflictHandler,
+                       @Nullable final ChangeEventListener<DocumentT> changeEventListener,
+                       @Nullable final ExceptionListener exceptionListener);
+
+  /**
+   * Set the conflict handler and and change event listener on this collection. This will start
+   * a background sync thread, and should be called before any CRUD operations are attempted.
+   * @deprecated configure(SyncConfiguration syncConfig)
+   *
+   * @param conflictHandler the conflict resolver to invoke when a conflict happens between local
+   *                         and remote events.
+   * @param changeEventListener the event listener to invoke when a change event happens for the
+   *                         document.
+   * @param exceptionListener the error listener to invoke when an irrecoverable error occurs
    * @param syncFrequency the syncFrequency at which to perform synchronization passes
    *
    * @return A Task that completes when Mobile Sync is configured, and the background sync thread

--- a/android/services/mongodb-remote/src/main/java/com/mongodb/stitch/android/services/mongodb/remote/internal/SyncImpl.java
+++ b/android/services/mongodb-remote/src/main/java/com/mongodb/stitch/android/services/mongodb/remote/internal/SyncImpl.java
@@ -58,6 +58,23 @@ public class SyncImpl<DocumentT> implements Sync<DocumentT> {
   @Override
   public Task<Void> configure(@NonNull final ConflictHandler<DocumentT> conflictHandler,
                               @Nullable final ChangeEventListener<DocumentT> changeEventListener,
+                              @Nullable final ExceptionListener exceptionListener) {
+    return this.dispatcher.dispatchTask(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        final SyncConfiguration syncConfiguration = new SyncConfiguration.Builder()
+            .withConflictHandler(conflictHandler)
+            .withChangeEventListener(changeEventListener)
+            .withExceptionListener(exceptionListener).build();
+        SyncImpl.this.proxy.configure(syncConfiguration);
+        return null;
+      }
+    });
+  }
+
+  @Override
+  public Task<Void> configure(@NonNull final ConflictHandler<DocumentT> conflictHandler,
+                              @Nullable final ChangeEventListener<DocumentT> changeEventListener,
                               @Nullable final ExceptionListener exceptionListener,
                               @Nullable final SyncFrequency syncFrequency) {
     return this.dispatcher.dispatchTask(new Callable<Void>() {

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncConfigurationUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncConfigurationUnitTests.kt
@@ -53,7 +53,7 @@ class SyncConfigurationUnitTests {
     fun testSyncConfigurationBuilderRequired() {
         try {
             val builder = SyncConfiguration.Builder()
-            val _ = builder.build()
+            builder.build()
         } catch (ex: SyncConfigurationException) {
             return
         }

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncConfigurationUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncConfigurationUnitTests.kt
@@ -53,7 +53,7 @@ class SyncConfigurationUnitTests {
     fun testSyncConfigurationBuilderRequired() {
         try {
             val builder = SyncConfiguration.Builder()
-            var config = builder.build()
+            val _ = builder.build()
         } catch (ex: SyncConfigurationException) {
             return
         }

--- a/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/ProxySyncMethods.kt
+++ b/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/ProxySyncMethods.kt
@@ -26,6 +26,13 @@ interface ProxySyncMethods {
         exceptionListener: ExceptionListener?
     ): Void?
 
+    fun configure(
+        conflictResolver: ConflictHandler<Document?>,
+        changeEventListener: ChangeEventListener<Document>?,
+        exceptionListener: ExceptionListener?,
+        syncFrequency: SyncFrequency?
+    ): Void?
+
     fun configure(syncConfig: SyncConfiguration): Void?
 
     fun updateSyncFrequency(syncFrequency: SyncFrequency): Void?

--- a/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
+++ b/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
@@ -934,15 +934,15 @@ class SyncIntTestProxy(private val syncTestRunner: SyncIntTestRunner) {
         val remoteColl = syncTestRunner.remoteMethods()
 
         // insert a document locally
-        val docToInsert = Document("hello", "world")
-        val insertedId = coll.insertOne(docToInsert).insertedId
+        var docToInsert = Document("hello", "world")
+        var insertedId = coll.insertOne(docToInsert).insertedId
 
         var hasConflictHandlerBeenInvoked = false
         var hasChangeEventListenerBeenInvoked = false
 
         // configure Sync, each entry with flags checking
         // that the listeners/handlers have been called
-        val changeEventListenerSemaphore = Semaphore(0)
+        var changeEventListenerSemaphore = Semaphore(0)
         coll.configure(
             ConflictHandler { _: BsonValue, _: ChangeEvent<Document>, remoteEvent: ChangeEvent<Document> ->
                 hasConflictHandlerBeenInvoked = true
@@ -954,6 +954,43 @@ class SyncIntTestProxy(private val syncTestRunner: SyncIntTestRunner) {
                 changeEventListenerSemaphore.release()
             },
             ExceptionListener { _, _ -> }
+        )
+
+        waitForAllStreamsOpen()
+
+        // insert a document remotely
+        remoteColl.insertOne(Document("_id", insertedId).append("fly", "away"))
+
+        // sync. assert that the conflict handler and
+        // change event listener have been called
+        streamAndSync()
+
+        assertTrue(changeEventListenerSemaphore.tryAcquire(10, TimeUnit.SECONDS))
+        Assert.assertTrue(hasConflictHandlerBeenInvoked)
+        Assert.assertTrue(hasChangeEventListenerBeenInvoked)
+
+        // Call configure again with a new frequency
+        docToInsert = Document("hello", "world")
+        insertedId = coll.insertOne(docToInsert).insertedId
+
+        hasConflictHandlerBeenInvoked = false
+        hasChangeEventListenerBeenInvoked = false
+
+        // configure Sync, each entry with flags checking
+        // that the listeners/handlers have been called
+        changeEventListenerSemaphore = Semaphore(0)
+        coll.configure(
+            ConflictHandler { _: BsonValue, _: ChangeEvent<Document>, remoteEvent: ChangeEvent<Document> ->
+                hasConflictHandlerBeenInvoked = true
+                assertEquals(remoteEvent.fullDocument!!["fly"], "away")
+                remoteEvent.fullDocument
+            },
+            ChangeEventListener { _: BsonValue, _: ChangeEvent<Document> ->
+                hasChangeEventListenerBeenInvoked = true
+                changeEventListenerSemaphore.release()
+            },
+            ExceptionListener { _, _ -> },
+            SyncFrequency.scheduled(100, TimeUnit.MINUTES, true)
         )
 
         waitForAllStreamsOpen()
@@ -2087,7 +2124,7 @@ class SyncIntTestProxy(private val syncTestRunner: SyncIntTestRunner) {
                 hasChangeEventListenerBeenInvoked = true
                 Thread(Runnable {
                     if (coll.count(Document("_id", docId)) == 0L) {
-                        fail("Did not find document with id ${docId.toString()}")
+                        fail("Did not find document with id $docId")
                     }
                     if (waitFor.decrementAndGet() == 0) {
                         changeEventListenerSemaphore.release()

--- a/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestRunner.kt
+++ b/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestRunner.kt
@@ -190,4 +190,7 @@ interface SyncIntTestRunner {
 
     @Test
     fun testUpdateSyncFrequency()
+
+    @Test
+    fun testFindOnReceivingChangeEvent()
 }


### PR DESCRIPTION
This adds a test that will now pass due to Doug's changes. Also I drove by adding the original configure() method back in 
