### PR TITLE
STITCH-2718 use update description deltas in mobile sync

### DIFF
--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/CompactChangeEvent.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/CompactChangeEvent.java
@@ -77,6 +77,18 @@ public final class CompactChangeEvent<DocumentT> extends BaseChangeEvent<Documen
   }
 
   /**
+   * Returns the MongoDB Mobile Sync version info of the document after this event.
+   *
+   * @return the sync document version info
+   */
+  public @Nonnull DocumentVersionInfo getStitchDocumentVersionInfo() {
+    return new DocumentVersionInfo(
+        stitchDocumentVersion,
+        getDocumentKey().get("_id")
+    );
+  }
+
+  /**
    * Returns the FNV-1a hash of the document as computed after the rules were applied, and after
    * the document version was removed from the document.
    *

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/UpdateDescription.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/UpdateDescription.java
@@ -144,26 +144,6 @@ public final class UpdateDescription {
   }
 
   /**
-   * Synthetically applies this update description to the provided BSON document.
-   *
-   * @param originalDoc the document to which to apply the update
-   * @return a clone of the original document, with this update description applied
-   */
-  public BsonDocument applyToBsonDocument(final BsonDocument originalDoc) {
-    final BsonDocument updatedDoc = originalDoc.clone();
-
-    for (final Map.Entry<String, BsonValue> entry : this.getUpdatedFields().entrySet()) {
-      updatedDoc.append(entry.getKey(), entry.getValue());
-    }
-
-    for (final String removedField : this.getRemovedFields()) {
-      updatedDoc.remove(removedField);
-    }
-
-    return updatedDoc;
-  }
-
-  /**
    * Unilaterally merge an update description into this update description.
    * @param otherDescription the update description to merge into this
    * @return this merged update description

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/UpdateDescription.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/UpdateDescription.java
@@ -46,19 +46,6 @@ public final class UpdateDescription {
   /**
    * Creates an update description with the specified updated fields and removed field names.
    * @param updatedFields Nested key-value pair representation of updated fields.
-   * @param removedFields Set of removed field names.
-   */
-  public UpdateDescription(
-      final BsonDocument updatedFields,
-      final Set<String> removedFields
-  ) {
-    this.updatedFields = updatedFields == null ? new BsonDocument() : updatedFields;
-    this.removedFields = removedFields == null ? new HashSet<>() : removedFields;
-  }
-
-  /**
-   * Creates an update description with the specified updated fields and removed field names.
-   * @param updatedFields Nested key-value pair representation of updated fields.
    * @param removedFields Collection of removed field names.
    */
   public UpdateDescription(

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/UpdateDescription.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/UpdateDescription.java
@@ -245,6 +245,15 @@ public final class UpdateDescription {
     );
   }
 
+  /**
+   * Determines whether this update description is empty.
+   *
+   * @return true if the update description is empty, false otherwise
+   */
+  public boolean isEmpty() {
+    return this.updatedFields.size() == 0 && this.removedFields.size() == 0;
+  }
+
   @Override
   public boolean equals(final Object obj) {
     if (obj == null || !obj.getClass().equals(UpdateDescription.class)) {

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/UpdateDescription.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/UpdateDescription.java
@@ -165,11 +165,11 @@ public final class UpdateDescription {
   public BsonDocument applyToBsonDocument(final BsonDocument originalDoc) {
     final BsonDocument updatedDoc = originalDoc.clone();
 
-    for (Map.Entry<String, BsonValue> entry : this.getUpdatedFields().entrySet()) {
+    for (final Map.Entry<String, BsonValue> entry : this.getUpdatedFields().entrySet()) {
       updatedDoc.append(entry.getKey(), entry.getValue());
     }
 
-    for (String removedField : this.getRemovedFields()) {
+    for (final String removedField : this.getRemovedFields()) {
       updatedDoc.remove(removedField);
     }
 

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/internal/ResultDecoders.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/internal/ResultDecoders.java
@@ -132,7 +132,7 @@ public class ResultDecoders {
   }
 
   @SuppressWarnings("unused")
-  static <DocumentT> Decoder<CompactChangeEvent<DocumentT>>
+  public static <DocumentT> Decoder<CompactChangeEvent<DocumentT>>
       compactChangeEventDecoder(final Codec<DocumentT> codec) {
     return new CompactChangeEventDecoder<>(codec);
   }

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/ConflictHandler.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/ConflictHandler.java
@@ -17,6 +17,7 @@
 package com.mongodb.stitch.core.services.mongodb.remote.sync;
 
 import com.mongodb.stitch.core.services.mongodb.remote.ChangeEvent;
+import com.mongodb.stitch.core.services.mongodb.remote.CompactChangeEvent;
 
 import org.bson.BsonValue;
 
@@ -34,8 +35,8 @@ public interface ConflictHandler<DocumentT> {
    * @param remoteEvent the conflicting remote event.
    * @return a resolution to the conflict between the given local and remote {@link ChangeEvent}s.
    */
-  DocumentT resolveConflict(
+  ConflictResolution resolveConflict(
       final BsonValue documentId,
       final ChangeEvent<DocumentT> localEvent,
-      final ChangeEvent<DocumentT> remoteEvent);
+      final CompactChangeEvent<DocumentT> remoteEvent);
 }

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/ConflictResolution.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/ConflictResolution.java
@@ -1,0 +1,69 @@
+package com.mongodb.stitch.core.services.mongodb.remote.sync;
+
+public abstract class ConflictResolution {
+
+  public enum ConflictResolutionType {
+    WITH_DOCUMENT,
+    FROM_LOCAL,
+    FROM_REMOTE
+  }
+
+  public static final class WithDocument<T> extends ConflictResolution {
+    private final T fullDocumentForResolution;
+
+    WithDocument(final T fullDocumentForResolution) {
+      this.fullDocumentForResolution = fullDocumentForResolution;
+    }
+
+    @Override
+    public ConflictResolutionType getType() {
+      return ConflictResolutionType.WITH_DOCUMENT;
+    }
+
+    public T getFullDocumentForResolution() {
+      return fullDocumentForResolution;
+    }
+  }
+
+  public static final class FromRemote extends ConflictResolution {
+
+    static final FromRemote instance = new FromRemote();
+
+    private FromRemote() {
+    }
+
+    @Override
+    public ConflictResolutionType getType() {
+      return ConflictResolutionType.FROM_REMOTE;
+    }
+
+  }
+
+  public static final class FromLocal extends ConflictResolution {
+
+    static final FromLocal instance = new FromLocal();
+
+    private FromLocal() {
+    }
+
+    @Override
+    public ConflictResolutionType getType() {
+      return ConflictResolutionType.FROM_LOCAL;
+    }
+
+  }
+
+  public static <T> ConflictResolution withDocument(T fullDocumentForResolution) {
+    return new WithDocument<>(fullDocumentForResolution);
+  }
+
+  public static ConflictResolution fromRemote() {
+    return FromRemote.instance;
+  }
+
+  public static ConflictResolution fromLocal() {
+    return FromLocal.instance;
+  }
+
+  public abstract ConflictResolutionType getType();
+}

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/ConflictResolution.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/ConflictResolution.java
@@ -1,13 +1,44 @@
+/*
+ * Copyright 2018-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.mongodb.stitch.core.services.mongodb.remote.sync;
 
+/**
+ * {@link ConflictResolution} represents a resolution to a MongoDB Mobile Sync conflict. Conflicts
+ * occur when a local pending write conflicts with an incoming remote change. The user-defined
+ * conflict handler method in a {@link ConflictHandler} returns a {@link ConflictResolution}.
+ */
 public abstract class ConflictResolution {
 
+  /**
+   * The different ways of resolving a conflict.
+   */
   public enum ConflictResolutionType {
     WITH_DOCUMENT,
     FROM_LOCAL,
     FROM_REMOTE
   }
 
+  /**
+   * {@link WithDocument} resolves a conflict by providing a new document that should be treated as
+   * the new source of truth. {@link WithDocument} is useful for conflict handlers where data from
+   * both the local and remote change events are used in resolving the conflict.
+   *
+   * @param <T> The type of document for this resolution.
+   */
   public static final class WithDocument<T> extends ConflictResolution {
     private final T fullDocumentForResolution;
 
@@ -20,13 +51,21 @@ public abstract class ConflictResolution {
       return ConflictResolutionType.WITH_DOCUMENT;
     }
 
+    /**
+     * Returns the full document that will be used to resolve the conflict.
+     *
+     * @return the full document that will be used to resolve the conflict
+     */
     public T getFullDocumentForResolution() {
       return fullDocumentForResolution;
     }
   }
 
+  /**
+   * {@link FromRemote} resolves a conflict by accepting the current state of the document on the
+   * remote MongoDB server. This may incur a remote call to the server.
+   */
   public static final class FromRemote extends ConflictResolution {
-
     static final FromRemote instance = new FromRemote();
 
     private FromRemote() {
@@ -39,8 +78,11 @@ public abstract class ConflictResolution {
 
   }
 
+  /**
+   * {@link FromLocal} resolves a conflict by accepting the current state of the document on the
+   * device. This local version will eventually be propagated to the remote server.
+   */
   public static final class FromLocal extends ConflictResolution {
-
     static final FromLocal instance = new FromLocal();
 
     private FromLocal() {
@@ -53,14 +95,30 @@ public abstract class ConflictResolution {
 
   }
 
+  /**
+   * Constructs a new {@link WithDocument} resolution with the provided document.
+   *
+   * @param fullDocumentForResolution The object representing the document that resolves the
+   *                                  conflict
+   */
   public static <T> ConflictResolution withDocument(T fullDocumentForResolution) {
     return new WithDocument<>(fullDocumentForResolution);
   }
 
+  /**
+   * Returns the {@link FromRemote} conflict resolution.
+   *
+   * @return the {@link FromRemote} conflict resolution.
+   */
   public static ConflictResolution fromRemote() {
     return FromRemote.instance;
   }
 
+  /**
+   * Returns the {@link FromLocal} conflict resolution.
+   *
+   * @return the {@link FromLocal} conflict resolution.
+   */
   public static ConflictResolution fromLocal() {
     return FromLocal.instance;
   }

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/ConflictResolution.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/ConflictResolution.java
@@ -65,7 +65,7 @@ public abstract class ConflictResolution {
    * {@link FromRemote} resolves a conflict by accepting the current state of the document on the
    * remote MongoDB server. This may incur a remote call to the server.
    */
-  public static final class FromRemote extends ConflictResolution {
+  static final class FromRemote extends ConflictResolution {
     static final FromRemote instance = new FromRemote();
 
     private FromRemote() {
@@ -82,7 +82,7 @@ public abstract class ConflictResolution {
    * {@link FromLocal} resolves a conflict by accepting the current state of the document on the
    * device. This local version will eventually be propagated to the remote server.
    */
-  public static final class FromLocal extends ConflictResolution {
+  static final class FromLocal extends ConflictResolution {
     static final FromLocal instance = new FromLocal();
 
     private FromLocal() {
@@ -126,7 +126,7 @@ public abstract class ConflictResolution {
   }
 
   /**
-   * Returns the enum type of this {@link ConflictResolution}.
+   * Returns the enum type of this {@link ConflictResolution}. For internal use only.
    *
    * @return the type of this {@link ConflictResolution}
    */

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/ConflictResolution.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/ConflictResolution.java
@@ -96,12 +96,14 @@ public abstract class ConflictResolution {
   }
 
   /**
-   * Constructs a new {@link WithDocument} resolution with the provided document.
+   * Returns a new {@link WithDocument} resolution with the provided document.
    *
    * @param fullDocumentForResolution The object representing the document that resolves the
    *                                  conflict
+   * @param <T> The Java type of the full document.
+   * @return the {@link WithDocument} conflict resolution with the provided full document.
    */
-  public static <T> ConflictResolution withDocument(T fullDocumentForResolution) {
+  public static <T> ConflictResolution withDocument(final T fullDocumentForResolution) {
     return new WithDocument<>(fullDocumentForResolution);
   }
 
@@ -123,5 +125,10 @@ public abstract class ConflictResolution {
     return FromLocal.instance;
   }
 
+  /**
+   * Returns the enum type of this {@link ConflictResolution}.
+   *
+   * @return the type of this {@link ConflictResolution}
+   */
   public abstract ConflictResolutionType getType();
 }

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/DefaultSyncConflictResolvers.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/DefaultSyncConflictResolvers.java
@@ -18,7 +18,6 @@ package com.mongodb.stitch.core.services.mongodb.remote.sync;
 
 import com.mongodb.stitch.core.services.mongodb.remote.ChangeEvent;
 import com.mongodb.stitch.core.services.mongodb.remote.CompactChangeEvent;
-import com.mongodb.stitch.core.services.mongodb.remote.OperationType;
 
 import org.bson.BsonValue;
 

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/DefaultSyncConflictResolvers.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/DefaultSyncConflictResolvers.java
@@ -17,6 +17,8 @@
 package com.mongodb.stitch.core.services.mongodb.remote.sync;
 
 import com.mongodb.stitch.core.services.mongodb.remote.ChangeEvent;
+import com.mongodb.stitch.core.services.mongodb.remote.CompactChangeEvent;
+import com.mongodb.stitch.core.services.mongodb.remote.OperationType;
 
 import org.bson.BsonValue;
 
@@ -34,12 +36,12 @@ public final class DefaultSyncConflictResolvers {
   public static <T> ConflictHandler<T> remoteWins() {
     return new ConflictHandler<T>() {
       @Override
-      public T resolveConflict(
+      public ConflictResolution resolveConflict(
           final BsonValue documentId,
           final ChangeEvent<T> localEvent,
-          final ChangeEvent<T> remoteEvent
+          final CompactChangeEvent<T> remoteEvent
       ) {
-        return remoteEvent.getFullDocument();
+        return ConflictResolution.fromRemote();
       }
     };
   }
@@ -53,12 +55,12 @@ public final class DefaultSyncConflictResolvers {
   public static <T> ConflictHandler<T> localWins() {
     return new ConflictHandler<T>() {
       @Override
-      public T resolveConflict(
+      public ConflictResolution resolveConflict(
           final BsonValue documentId,
           final ChangeEvent<T> localEvent,
-          final ChangeEvent<T> remoteEvent
+          final CompactChangeEvent<T> remoteEvent
       ) {
-        return localEvent.getFullDocument();
+        return ConflictResolution.fromLocal();
       }
     };
   }

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/CoreDocumentSynchronizationConfig.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/CoreDocumentSynchronizationConfig.java
@@ -450,11 +450,11 @@ public class CoreDocumentSynchronizationConfig {
       case REPLACE:
         switch (newestChangeEvent.getOperationType()) {
           case UPDATE:
-            if(newestChangeEvent.getUpdateDescription() == null) {
+            if (newestChangeEvent.getUpdateDescription() == null) {
               throw new IllegalStateException("UPDATE event should have update description");
             }
 
-            if(lastUncommittedChangeEvent.getFullDocument() == null) {
+            if (lastUncommittedChangeEvent.getFullDocument() == null) {
               throw new IllegalStateException("REPLACE event should have full document");
             }
 

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/CoreDocumentSynchronizationConfig.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/CoreDocumentSynchronizationConfig.java
@@ -450,8 +450,10 @@ public class CoreDocumentSynchronizationConfig {
       case REPLACE:
         switch (newestChangeEvent.getOperationType()) {
           case UPDATE:
-            if (newestChangeEvent.getUpdateDescription() == null) {
-              throw new IllegalStateException("UPDATE event should have update description");
+            if (newestChangeEvent.getFullDocument() == null) {
+              throw new IllegalStateException(
+                  "a locally synthesized UPDATE event should have update description"
+              );
             }
 
             if (lastUncommittedChangeEvent.getFullDocument() == null) {
@@ -461,8 +463,7 @@ public class CoreDocumentSynchronizationConfig {
             return new ChangeEvent<>(
                 newestChangeEvent.getId(),
                 OperationType.REPLACE,
-                newestChangeEvent.getUpdateDescription()
-                    .applyToBsonDocument(lastUncommittedChangeEvent.getFullDocument()),
+                newestChangeEvent.getFullDocument(),
                 newestChangeEvent.getNamespace(),
                 newestChangeEvent.getDocumentKey(),
                 null,

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
@@ -606,10 +606,12 @@ public class DataSynchronizer implements NetworkMonitor.StateListener {
   public void stop() {
     syncLock.lock();
     try {
+      if (instanceChangeStreamListener != null) {
+        instanceChangeStreamListener.stop();
+      }
       if (syncThread == null) {
         return;
       }
-      instanceChangeStreamListener.stop();
       syncThread.interrupt();
       try {
         syncThread.join();

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizer.java
@@ -61,7 +61,6 @@ import com.mongodb.stitch.core.services.mongodb.remote.sync.ConflictHandler;
 import com.mongodb.stitch.core.services.mongodb.remote.sync.ConflictResolution;
 import com.mongodb.stitch.core.services.mongodb.remote.sync.internal.SyncFrequency.Scheduled;
 import com.mongodb.stitch.core.services.mongodb.remote.sync.internal.SyncFrequency.SyncFrequencyType;
-import com.sun.corba.se.impl.orbutil.concurrent.Sync;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DocumentVersionInfo.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DocumentVersionInfo.java
@@ -233,10 +233,6 @@ public final class DocumentVersionInfo {
    * @return a BsonDocument representing a synchronization version
    */
   static BsonDocument getFreshVersionDocument() {
-    System.err.println("I'M PRODUCING A FRESH VERSION DOCUMENT!!");
-    for (StackTraceElement stackTraceElement : Thread.currentThread().getStackTrace()) {
-      System.err.println(stackTraceElement.toString());
-    }
     final BsonDocument versionDoc = new BsonDocument();
 
     versionDoc.append(Fields.SYNC_PROTOCOL_VERSION_FIELD, new BsonInt32(1));

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DocumentVersionInfo.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DocumentVersionInfo.java
@@ -102,6 +102,17 @@ public final class DocumentVersionInfo {
 
       return asDoc;
     }
+
+    @Override
+    public boolean equals(Object otherVersionObj) {
+      if (!(otherVersionObj instanceof Version)) {
+        return false;
+      }
+
+      final Version otherVersion = (Version) otherVersionObj;
+
+      return this.toBsonDocument().equals(otherVersion.toBsonDocument());
+    }
   }
 
   private DocumentVersionInfo(
@@ -222,6 +233,10 @@ public final class DocumentVersionInfo {
    * @return a BsonDocument representing a synchronization version
    */
   static BsonDocument getFreshVersionDocument() {
+    System.err.println("I'M PRODUCING A FRESH VERSION DOCUMENT!!");
+    for (StackTraceElement stackTraceElement : Thread.currentThread().getStackTrace()) {
+      System.err.println(stackTraceElement.toString());
+    }
     final BsonDocument versionDoc = new BsonDocument();
 
     versionDoc.append(Fields.SYNC_PROTOCOL_VERSION_FIELD, new BsonInt32(1));

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DocumentVersionInfo.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DocumentVersionInfo.java
@@ -123,6 +123,20 @@ public final class DocumentVersionInfo {
     }
   }
 
+  public DocumentVersionInfo(
+      @Nullable final Version version,
+      @Nullable final BsonValue documentId
+  ) {
+    this.version = version;
+    this.versionDoc = (version != null) ? version.toBsonDocument() : null;
+
+    if (documentId != null) {
+      this.filter = getVersionedFilter(documentId, this.versionDoc);
+    } else {
+      this.filter = null;
+    }
+  }
+
   @Nullable BsonDocument getVersionDoc() {
     return versionDoc;
   }

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DocumentVersionInfo.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DocumentVersionInfo.java
@@ -104,7 +104,7 @@ public final class DocumentVersionInfo {
     }
 
     @Override
-    public boolean equals(Object otherVersionObj) {
+    public boolean equals(final Object otherVersionObj) {
       if (!(otherVersionObj instanceof Version)) {
         return false;
       }
@@ -112,6 +112,11 @@ public final class DocumentVersionInfo {
       final Version otherVersion = (Version) otherVersionObj;
 
       return this.toBsonDocument().equals(otherVersion.toBsonDocument());
+    }
+
+    @Override
+    public int hashCode() {
+      return super.hashCode();
     }
   }
 

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/InstanceChangeStreamListener.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/InstanceChangeStreamListener.java
@@ -18,7 +18,7 @@ package com.mongodb.stitch.core.services.mongodb.remote.sync.internal;
 
 import com.mongodb.MongoNamespace;
 import com.mongodb.stitch.core.internal.common.Callback;
-import com.mongodb.stitch.core.services.mongodb.remote.ChangeEvent;
+import com.mongodb.stitch.core.services.mongodb.remote.CompactChangeEvent;
 
 import java.util.Map;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -64,10 +64,10 @@ interface InstanceChangeStreamListener {
    * Queue a one-off watcher for the next event pass.
    */
   void addWatcher(final MongoNamespace namespace,
-                              final Callback<ChangeEvent<BsonDocument>, Object> watcher);
+                              final Callback<CompactChangeEvent<BsonDocument>, Object> watcher);
 
   void removeWatcher(final MongoNamespace namespace,
-                     final Callback<ChangeEvent<BsonDocument>, Object> watcher);
+                     final Callback<CompactChangeEvent<BsonDocument>, Object> watcher);
 
   /**
    * Requests that the given namespace be started listening to for change events.
@@ -89,7 +89,7 @@ interface InstanceChangeStreamListener {
    * @param namespace the namespace to get events for.
    * @return the latest change events for a given namespace.
    */
-  Map<BsonValue, ChangeEvent<BsonDocument>> getEventsForNamespace(
+  Map<BsonValue, CompactChangeEvent<BsonDocument>> getEventsForNamespace(
       final MongoNamespace namespace);
 
   /**
@@ -111,7 +111,7 @@ interface InstanceChangeStreamListener {
    * @return the latest unprocessed change event for the given document ID and namespace, or null
    *         if none exists.
    */
-  @Nullable ChangeEvent<BsonDocument> getUnprocessedEventForDocumentId(
+  @Nullable CompactChangeEvent<BsonDocument> getUnprocessedEventForDocumentId(
           final MongoNamespace namespace,
           final BsonValue documentId);
 }

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/InstanceChangeStreamListenerImpl.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/InstanceChangeStreamListenerImpl.java
@@ -21,7 +21,7 @@ import com.mongodb.stitch.core.internal.common.AuthMonitor;
 import com.mongodb.stitch.core.internal.common.Callback;
 import com.mongodb.stitch.core.internal.net.NetworkMonitor;
 import com.mongodb.stitch.core.services.internal.CoreStitchServiceClient;
-import com.mongodb.stitch.core.services.mongodb.remote.ChangeEvent;
+import com.mongodb.stitch.core.services.mongodb.remote.CompactChangeEvent;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -141,7 +141,7 @@ final class InstanceChangeStreamListenerImpl implements InstanceChangeStreamList
 
   @Override
   public void addWatcher(final MongoNamespace namespace,
-                         final Callback<ChangeEvent<BsonDocument>, Object> watcher) {
+                         final Callback<CompactChangeEvent<BsonDocument>, Object> watcher) {
     if (nsStreamers.containsKey(namespace)) {
       nsStreamers.get(namespace).addWatcher(watcher);
     }
@@ -149,7 +149,7 @@ final class InstanceChangeStreamListenerImpl implements InstanceChangeStreamList
 
   @Override
   public void removeWatcher(final MongoNamespace namespace,
-                            final Callback<ChangeEvent<BsonDocument>, Object> watcher) {
+                            final Callback<CompactChangeEvent<BsonDocument>, Object> watcher) {
     if (nsStreamers.containsKey(namespace)) {
       nsStreamers.get(namespace).removeWatcher(watcher);
     }
@@ -206,7 +206,7 @@ final class InstanceChangeStreamListenerImpl implements InstanceChangeStreamList
    * @param namespace the namespace to get events for.
    * @return the latest change events for a given namespace.
    */
-  public Map<BsonValue, ChangeEvent<BsonDocument>> getEventsForNamespace(
+  public Map<BsonValue, CompactChangeEvent<BsonDocument>> getEventsForNamespace(
       final MongoNamespace namespace
   ) {
     this.instanceLock.readLock().lock();
@@ -246,7 +246,7 @@ final class InstanceChangeStreamListenerImpl implements InstanceChangeStreamList
    * @return the latest unprocessed change event for the given document ID and namespace, or null
    *         if none exists.
    */
-  public @Nullable ChangeEvent<BsonDocument> getUnprocessedEventForDocumentId(
+  public @Nullable CompactChangeEvent<BsonDocument> getUnprocessedEventForDocumentId(
           final MongoNamespace namespace,
           final BsonValue documentId
   ) {

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/NamespaceChangeStreamListener.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/NamespaceChangeStreamListener.java
@@ -228,6 +228,7 @@ public class NamespaceChangeStreamListener implements Closeable {
         this.nsConfig.setStale(true);
         isOpen = true;
       } else {
+        System.err.println("OOOOPSIES WE DIDNT OPEN THE STREAM!!!!!!!!!!!!!!!" + currentStream);
         isOpen = false;
       }
     } finally {

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/NamespaceChangeStreamListener.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/NamespaceChangeStreamListener.java
@@ -228,7 +228,6 @@ public class NamespaceChangeStreamListener implements Closeable {
         this.nsConfig.setStale(true);
         isOpen = true;
       } else {
-        System.err.println("OOOOPSIES WE DIDNT OPEN THE STREAM!!!!!!!!!!!!!!!" + currentStream);
         isOpen = false;
       }
     } finally {

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/NamespaceSynchronizationConfig.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/NamespaceSynchronizationConfig.java
@@ -332,6 +332,7 @@ public class NamespaceSynchronizationConfig implements Iterable<CoreDocumentSync
   }
 
   void setStale(final boolean stale) throws InterruptedException {
+    System.err.println("SETTING A NAMESPACE STALENESS TO " + stale + "!!!!!!!");
     nsLock.writeLock().lockInterruptibly();
     try {
       namespacesColl.updateOne(
@@ -360,6 +361,17 @@ public class NamespaceSynchronizationConfig implements Iterable<CoreDocumentSync
       // eat this
     } finally {
       nsLock.writeLock().unlock();
+    }
+  }
+
+  public boolean isStale() {
+    nsLock.readLock().lock();
+    try {
+      final BsonDocument filter = getNsFilter(getNamespace());
+      filter.append(ConfigCodec.Fields.IS_STALE, BsonBoolean.TRUE);
+      return docsColl.countDocuments(filter) == 1;
+    } finally {
+      nsLock.readLock().unlock();
     }
   }
 

--- a/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/NamespaceSynchronizationConfig.java
+++ b/core/services/mongodb-remote/src/main/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/NamespaceSynchronizationConfig.java
@@ -332,7 +332,6 @@ public class NamespaceSynchronizationConfig implements Iterable<CoreDocumentSync
   }
 
   void setStale(final boolean stale) throws InterruptedException {
-    System.err.println("SETTING A NAMESPACE STALENESS TO " + stale + "!!!!!!!");
     nsLock.writeLock().lockInterruptibly();
     try {
       namespacesColl.updateOne(

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerCRUDUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerCRUDUnitTests.kt
@@ -52,7 +52,6 @@ class DataSynchronizerCRUDUnitTests {
                 ctx.testDocumentHash,
                 UpdateDescription(BsonDocument(), HashSet()),
                 TestVersionState.NEXT
-
             )
             // set a different update doc than the remote
             ctx.updateDocument = BsonDocument("\$inc", BsonDocument("count", BsonInt32(2)))

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerCRUDUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerCRUDUnitTests.kt
@@ -30,7 +30,6 @@ import org.mockito.Mockito.`when`
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import java.lang.Exception
-import java.util.Collections
 
 class DataSynchronizerCRUDUnitTests {
     companion object {

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerUnitTests.kt
@@ -21,10 +21,8 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.ArgumentCaptor
-import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.eq
-import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
@@ -484,7 +482,6 @@ class DataSynchronizerUnitTests {
         val ctx = harness.freshTestContext()
 
         ctx.dataSynchronizer.syncDocumentsFromRemote(ctx.namespace, ctx.testDocumentId)
-
 
         // populate the remote collection with the test document, and simulate a fresh stream
         // that triggers a stale fetch

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerUnitTests.kt
@@ -1121,11 +1121,17 @@ class DataSynchronizerUnitTests {
         ctx.dataSynchronizer.syncDocumentsFromRemote(ctx.namespace, ctx.testDocumentId)
 
         // this should not hang to wait for the missing document
+        ctx.waitForDataSynchronizerStreams()
+        ctx.doSyncPass()
+
+        // the initial stale fetch should have occurred
+        verify(ctx.collectionMock, times(1)).find(any())
+
         ctx.doSyncPass()
 
         // the remote collection should not have been polled to
         // see if the missing document is now present
-        verify(ctx.collectionMock, times(0)).find(any())
+        verify(ctx.collectionMock, times(1)).find(any())
 
         // simulate a disconnect/reconnect where the document appears after reconnect
         ctx.mockFindResult(ctx.testDocument)
@@ -1133,7 +1139,7 @@ class DataSynchronizerUnitTests {
 
         ctx.doSyncPass()
 
-        verify(ctx.collectionMock, times(1)).find(any())
+        verify(ctx.collectionMock, times(2)).find(any())
 
         val localDoc = ctx.dataSynchronizer
                 .find(ctx.namespace, BsonDocument().append("_id", ctx.testDocumentId)).firstOrNull()

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerUnitTests.kt
@@ -2,8 +2,6 @@ package com.mongodb.stitch.core.services.mongodb.remote.sync.internal
 
 import com.mongodb.stitch.core.services.mongodb.remote.RemoteUpdateResult
 import com.mongodb.stitch.core.services.mongodb.remote.UpdateDescription
-import com.mongodb.stitch.core.services.mongodb.remote.internal.CoreRemoteFindIterable
-import com.mongodb.stitch.core.services.mongodb.remote.internal.CoreRemoteFindIterableImpl
 import com.mongodb.stitch.core.services.mongodb.remote.sync.internal.SyncUnitTestHarness.Companion.withoutSyncVersion
 import com.mongodb.stitch.server.services.mongodb.local.internal.ServerEmbeddedMongoClientFactory
 
@@ -23,8 +21,6 @@ import org.junit.Test
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.eq
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import java.lang.Exception

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/DataSynchronizerUnitTests.kt
@@ -363,7 +363,6 @@ class DataSynchronizerUnitTests {
         ctx.mockUpdateResult(RemoteUpdateResult(1, 1, null))
         val pseudoUpdatedDocument = ctx.testDocument.clone()
 
-        System.err.println("pseudoUpdatedDocument" + pseudoUpdatedDocument.toJson())
         ctx.queueConsumableRemoteUpdateEvent(
             pseudoUpdatedDocument,
             TestVersionState.SAME

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/NamespaceChangeStreamListenerUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/NamespaceChangeStreamListenerUnitTests.kt
@@ -83,7 +83,9 @@ class NamespaceChangeStreamListenerUnitTests {
 
         // assert that, with an expected ChangeEvent, the event is stored
         // and the stream remains open
-        val expectedChangeEvent = ChangeEvents.changeEventForLocalInsert(ctx.namespace, ctx.testDocument, true)
+        val expectedChangeEvent = ChangeEvents.compactChangeEventForLocalInsert(
+            ctx.testDocument, true
+        )
         ctx.nextStreamEvent = Event.Builder().withEventName("message").withData(
             expectedChangeEvent.toBsonDocument().toJson()
         ).build()

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
@@ -900,7 +900,7 @@ class SyncUnitTestHarness : Closeable {
     }
 
     private val unclosedDataSynchronizers: HashSet<DataSynchronizer?> = HashSet()
-    
+
     internal fun freshTestContext(shouldPreconfigure: Boolean = true): DataSynchronizerTestContext {
         unclosedDataSynchronizers.forEach {
             it?.close()

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
@@ -200,8 +200,6 @@ class SyncUnitTestHarness : Closeable {
         fun compareEvents(expectedEvent: CompactChangeEvent<BsonDocument>, actualEvent: CompactChangeEvent<BsonDocument>) {
             compareBaseEvents(expectedEvent, actualEvent)
 
-//            System.err.println(expectedEvent.stitchDocumentVersion!!.toBsonDocument().toJson())
-//            System.err.println(actualEvent.stitchDocumentVersion!!.toBsonDocument().toJson())
             Assert.assertEquals(expectedEvent.stitchDocumentVersion, actualEvent.stitchDocumentVersion)
             Assert.assertEquals(expectedEvent.stitchDocumentHash, actualEvent.stitchDocumentHash)
         }

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
@@ -892,12 +892,19 @@ class SyncUnitTestHarness : Closeable {
         }
 
         latestCtx?.dataSynchronizer?.close()
+
+        unclosedDataSynchronizers.forEach {
+            it?.close()
+        }
+        unclosedDataSynchronizers.clear()
     }
 
     private val unclosedDataSynchronizers: HashSet<DataSynchronizer?> = HashSet()
-
+    
     internal fun freshTestContext(shouldPreconfigure: Boolean = true): DataSynchronizerTestContext {
-        unclosedDataSynchronizers.forEach { it?.close() }
+        unclosedDataSynchronizers.forEach {
+            it?.close()
+        }
         unclosedDataSynchronizers.clear()
 
         latestCtx?.dataSynchronizer?.close()

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
@@ -15,11 +15,14 @@ import com.mongodb.stitch.core.internal.net.NetworkMonitor
 import com.mongodb.stitch.core.internal.net.Stream
 import com.mongodb.stitch.core.services.internal.CoreStitchServiceClient
 import com.mongodb.stitch.core.services.internal.CoreStitchServiceClientImpl
+import com.mongodb.stitch.core.services.mongodb.remote.BaseChangeEvent
 import com.mongodb.stitch.core.services.mongodb.remote.ChangeEvent
+import com.mongodb.stitch.core.services.mongodb.remote.CompactChangeEvent
 import com.mongodb.stitch.core.services.mongodb.remote.ExceptionListener
 import com.mongodb.stitch.core.services.mongodb.remote.OperationType
 import com.mongodb.stitch.core.services.mongodb.remote.RemoteDeleteResult
 import com.mongodb.stitch.core.services.mongodb.remote.RemoteUpdateResult
+import com.mongodb.stitch.core.services.mongodb.remote.UpdateDescription
 import com.mongodb.stitch.core.services.mongodb.remote.internal.CoreRemoteFindIterable
 import com.mongodb.stitch.core.services.mongodb.remote.internal.CoreRemoteMongoClientImpl
 import com.mongodb.stitch.core.services.mongodb.remote.internal.CoreRemoteMongoCollectionImpl
@@ -27,6 +30,7 @@ import com.mongodb.stitch.core.services.mongodb.remote.internal.CoreRemoteMongoD
 import com.mongodb.stitch.core.services.mongodb.remote.internal.ResultDecoders
 import com.mongodb.stitch.core.services.mongodb.remote.sync.ChangeEventListener
 import com.mongodb.stitch.core.services.mongodb.remote.sync.ConflictHandler
+import com.mongodb.stitch.core.services.mongodb.remote.sync.ConflictResolution
 import com.mongodb.stitch.core.services.mongodb.remote.sync.CoreSync
 import com.mongodb.stitch.server.services.mongodb.local.internal.ServerEmbeddedMongoClientFactory
 import org.bson.BsonDocument
@@ -60,6 +64,7 @@ import java.util.Collections
 import java.util.Random
 import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import java.util.concurrent.locks.ReentrantLock
 import java.util.concurrent.locks.ReentrantReadWriteLock
 
@@ -79,12 +84,15 @@ class SyncUnitTestHarness : Closeable {
             override fun resolveConflict(
                 documentId: BsonValue?,
                 localEvent: ChangeEvent<BsonDocument>?,
-                remoteEvent: ChangeEvent<BsonDocument>?
-            ): BsonDocument? {
+                remoteEvent: CompactChangeEvent<BsonDocument>?
+            ): ConflictResolution {
                 if (exceptionToThrow != null) {
                     throw exceptionToThrow!!
                 }
-                return if (shouldConflictBeResolvedByRemote) remoteEvent?.fullDocument else localEvent?.fullDocument
+                return when (shouldConflictBeResolvedByRemote) {
+                    true -> ConflictResolution.fromRemote()
+                    false -> ConflictResolution.fromLocal()
+                }
             }
         }
 
@@ -183,6 +191,22 @@ class SyncUnitTestHarness : Closeable {
          * @Param actualEvent actual event generated
          */
         fun compareEvents(expectedEvent: ChangeEvent<BsonDocument>, actualEvent: ChangeEvent<BsonDocument>) {
+            compareBaseEvents(expectedEvent, actualEvent)
+
+            Assert.assertEquals(expectedEvent.id, actualEvent.id)
+            Assert.assertEquals(expectedEvent.namespace, actualEvent.namespace)
+        }
+
+        fun compareEvents(expectedEvent: CompactChangeEvent<BsonDocument>, actualEvent: CompactChangeEvent<BsonDocument>) {
+            compareBaseEvents(expectedEvent, actualEvent)
+
+//            System.err.println(expectedEvent.stitchDocumentVersion!!.toBsonDocument().toJson())
+//            System.err.println(actualEvent.stitchDocumentVersion!!.toBsonDocument().toJson())
+            Assert.assertEquals(expectedEvent.stitchDocumentVersion, actualEvent.stitchDocumentVersion)
+            Assert.assertEquals(expectedEvent.stitchDocumentHash, actualEvent.stitchDocumentHash)
+        }
+
+        private fun compareBaseEvents(expectedEvent: BaseChangeEvent<BsonDocument>, actualEvent: BaseChangeEvent<BsonDocument>) {
             // assert that our actualEvent is correct
             Assert.assertEquals(expectedEvent.operationType, actualEvent.operationType)
             Assert.assertEquals(expectedEvent.documentKey, actualEvent.documentKey)
@@ -194,8 +218,7 @@ class SyncUnitTestHarness : Closeable {
             } else {
                 Assert.assertEquals(expectedEvent.fullDocument, withoutSyncVersion(actualEvent.fullDocument))
             }
-            Assert.assertEquals(expectedEvent.id, actualEvent.id)
-            Assert.assertEquals(expectedEvent.namespace, actualEvent.namespace)
+
             Assert.assertEquals(expectedEvent.updateDescription!!.removedFields, actualEvent.updateDescription!!.removedFields)
             Assert.assertEquals(expectedEvent.updateDescription!!.updatedFields, actualEvent.updateDescription!!.updatedFields)
 
@@ -272,7 +295,7 @@ class SyncUnitTestHarness : Closeable {
             Mockito.mock(CoreRemoteMongoCollectionImpl::class.java) as CoreRemoteMongoCollectionImpl<BsonDocument>
 
         override var nextStreamEvent: Event = Event.Builder().withEventName("MOCK").build()
-        private val streamMock = Stream(TestEventStream(this), ResultDecoders.changeEventDecoder(BsonDocumentCodec()))
+        private val streamMock = Stream(TestEventStream(this), ResultDecoders.compactChangeEventDecoder(BsonDocumentCodec()))
         override val testDocument = newDoc("count", BsonInt32(1))
         override val testDocumentId: BsonObjectId by lazy { testDocument["_id"] as BsonObjectId }
         override val testDocumentFilter by lazy { BsonDocument("_id", testDocumentId) }
@@ -299,6 +322,15 @@ class SyncUnitTestHarness : Closeable {
                 this.conflictHandler.exceptionToThrow = value
                 field = value
             }
+
+        override val testDocumentVersion: BsonDocument?
+            get() =
+                this.testDocument.getDocument("__stitch_sync_version", null)
+                    ?: getVersionForTestDocument()
+
+        override val testDocumentHash: Long
+            get() = HashUtils.hash(DataSynchronizer.sanitizeDocument(this.testDocument))
+
 
         var changeEventListener = newChangeEventListener()
             private set
@@ -390,7 +422,7 @@ class SyncUnitTestHarness : Closeable {
             Mockito.`when`(service.streamFunction(
                 ArgumentMatchers.anyString(),
                 ArgumentMatchers.anyList<Any>(),
-                ArgumentMatchers.eq(ResultDecoders.changeEventDecoder(BsonDocumentCodec())))
+                ArgumentMatchers.eq(ResultDecoders.compactChangeEventDecoder(BsonDocumentCodec())))
             ).thenReturn(streamMock)
 
             val databaseSpy = Mockito.mock(CoreRemoteMongoDatabaseImpl::class.java)
@@ -435,8 +467,14 @@ class SyncUnitTestHarness : Closeable {
 
         override fun waitForDataSynchronizerStreams() {
             waitLock.lock()
+            var counter = 0
             while (!dataSynchronizer.areAllStreamsOpen()) {
+                counter += 1
                 Thread.sleep(500)
+
+                if (counter > 10000 /*ms*/ / 500 /*ms/tick*/) {
+                    throw TimeoutException("DataSynchronizer streams never opened after 10 seconds")
+                }
             }
             waitLock.unlock()
             assertTrue(dataSynchronizer.areAllStreamsOpen())
@@ -502,7 +540,7 @@ class SyncUnitTestHarness : Closeable {
 
         override fun queueConsumableRemoteInsertEvent() {
             `when`(dataSynchronizer.getEventsForNamespace(any())).thenReturn(
-                mapOf(testDocument to ChangeEvents.changeEventForLocalInsert(namespace, testDocument, true)),
+                mapOf(testDocument to ChangeEvents.compactChangeEventForLocalInsert(testDocument, true)),
                 mapOf())
         }
 
@@ -528,52 +566,148 @@ class SyncUnitTestHarness : Closeable {
 
         override fun queueConsumableRemoteUpdateEvent(
             id: BsonValue,
-            document: BsonDocument,
+            previousVersion: BsonDocument?,
+            expectedNewHash: Long,
+            remoteUpdate: UpdateDescription,
             versionState: TestVersionState
         ) {
-            val fakeUpdateDoc = document.clone()
-            val cachedVersion = fakeUpdateDoc["__stitch_sync_version"] ?: getVersionForTestDocument()
+            val newVersion: BsonDocument?
 
-            if (cachedVersion != null) {
-                val documentVersionInfo = DocumentVersionInfo.fromVersionDoc(cachedVersion.asDocument())
-                when (versionState) {
+            if (previousVersion != null) {
+                val documentVersionInfo = DocumentVersionInfo.fromVersionDoc(previousVersion.asDocument())
+                newVersion = when (versionState) {
                     TestVersionState.NONE ->
-                        fakeUpdateDoc.remove("__stitch_sync_version")
+                        null
                     TestVersionState.PREVIOUS -> {
                         if (documentVersionInfo.version.versionCounter <= 0) {
                             throw IllegalStateException("Version cannot be less than zero")
                         }
-                        fakeUpdateDoc["__stitch_sync_version"] =
-                            documentVersionInfo.versionDoc?.append("v", BsonInt64(documentVersionInfo.version.versionCounter - 1))
+                        documentVersionInfo
+                            .versionDoc?.append(
+                            "v",
+                            BsonInt64(documentVersionInfo.version.versionCounter - 1)
+                        )
+
                     }
                     TestVersionState.SAME ->
-                        fakeUpdateDoc["__stitch_sync_version"] = documentVersionInfo.versionDoc
+                        documentVersionInfo.versionDoc
                     TestVersionState.NEXT ->
-                        fakeUpdateDoc["__stitch_sync_version"] = documentVersionInfo.getNextVersion()
+                        documentVersionInfo.nextVersion
                     TestVersionState.NEW ->
-                        fakeUpdateDoc["__stitch_sync_version"] = DocumentVersionInfo.getFreshVersionDocument()
+                        DocumentVersionInfo.getFreshVersionDocument()
+                }
+            } else {
+                if (versionState == TestVersionState.NEW) {
+                    newVersion = DocumentVersionInfo.getFreshVersionDocument()
+                } else {
+                    newVersion = null
                 }
             }
+
+            if(newVersion == null) {
+                remoteUpdate.removedFields.add("__stitch_sync_version")
+            } else {
+                remoteUpdate.updatedFields.append("__stitch_sync_version", newVersion)
+            }
+
             `when`(dataSynchronizer.getEventsForNamespace(any())).thenReturn(
-                mapOf(document to ChangeEvents.changeEventForLocalUpdate(
-                    namespace, id, null, fakeUpdateDoc, false)),
+                mapOf(id to ChangeEvents.compactChangeEventForLocalUpdate(
+                    id,
+                    remoteUpdate,
+                    newVersion,
+                    expectedNewHash,
+                    false
+                )),
+                mapOf())
+        }
+
+
+        override fun queueConsumableRemoteUpdateEvent(
+            fromExpectedDoc: BsonDocument,
+            versionState: TestVersionState
+        ) {
+            queueConsumableRemoteUpdateEvent(
+                id = fromExpectedDoc.get("_id")!!,
+                previousVersion = testDocumentVersion,
+                expectedNewHash = HashUtils.hash(DataSynchronizer.sanitizeDocument(fromExpectedDoc)),
+                remoteUpdate = UpdateDescription.diff(testDocument, fromExpectedDoc),
+                versionState = versionState
+            )
+        }
+
+        override fun queueConsumableRemoteReplaceEvent(
+            fromExpectedDoc: BsonDocument,
+            versionState: TestVersionState
+        ) {
+            val previousVersion =
+                fromExpectedDoc.getDocument("__stitch_sync_version", null)
+            val newVersion: BsonDocument?
+            val newDoc = fromExpectedDoc.clone()
+
+
+            if (previousVersion != null) {
+                val documentVersionInfo = DocumentVersionInfo.fromVersionDoc(previousVersion.asDocument())
+                newVersion = when (versionState) {
+                    TestVersionState.NONE ->
+                        null
+                    TestVersionState.PREVIOUS -> {
+                        if (documentVersionInfo.version.versionCounter <= 0) {
+                            throw IllegalStateException("Version cannot be less than zero")
+                        }
+                        documentVersionInfo
+                            .versionDoc?.append(
+                            "v",
+                            BsonInt64(documentVersionInfo.version.versionCounter - 1)
+                        )
+
+                    }
+                    TestVersionState.SAME ->
+                        documentVersionInfo.versionDoc
+                    TestVersionState.NEXT ->
+                        documentVersionInfo.nextVersion
+                    TestVersionState.NEW ->
+                        DocumentVersionInfo.getFreshVersionDocument()
+                }
+            } else {
+                if (versionState == TestVersionState.NEW) {
+                    newVersion = DocumentVersionInfo.getFreshVersionDocument()
+                } else {
+                    newVersion = null
+                }
+            }
+
+            if(newVersion == null) {
+                newDoc.remove("__stitch_sync_version")
+            } else {
+                newDoc.append("__stitch_sync_version", newVersion)
+            }
+
+            val id = fromExpectedDoc["_id"]
+
+            `when`(dataSynchronizer.getEventsForNamespace(any())).thenReturn(
+                mapOf(id to ChangeEvents.compactChangeEventForLocalReplace(
+                    id,
+                    newDoc,
+                    false
+                )),
                 mapOf())
         }
 
         override fun queueConsumableRemoteDeleteEvent() {
             `when`(dataSynchronizer.getEventsForNamespace(any())).thenReturn(
-                mapOf(testDocument to ChangeEvents.changeEventForLocalDelete(namespace, testDocumentId, true)),
+                mapOf(testDocument to ChangeEvents.compactChangeEventForLocalDelete(
+                    testDocumentId, true)),
                 mapOf())
         }
 
         override fun queueConsumableRemoteUnknownEvent() {
             `when`(dataSynchronizer.getEventsForNamespace(any())).thenReturn(
-                mapOf(testDocument to ChangeEvent(
-                        BsonDocument("_id", testDocumentId),
+                mapOf(testDocument to CompactChangeEvent(
                         OperationType.UNKNOWN,
                         testDocument,
-                        namespace,
                         BsonDocument("_id", testDocumentId),
+                        null,
+                        null,
                         null,
                         true)), mapOf())
         }
@@ -596,6 +730,10 @@ class SyncUnitTestHarness : Closeable {
         override fun findTestDocumentConfig(): CoreDocumentSynchronizationConfig? {
             return dataSynchronizer.syncConfig.getNamespaceConfig(namespace).docsColl.find(
                     BsonDocument("document_id", testDocumentId)).firstOrNull()
+        }
+
+        override fun setNamespaceStale(isStale: Boolean) {
+            return dataSynchronizer.syncConfig.getNamespaceConfig(namespace).setStale(isStale)
         }
 
         override fun verifyChangeEventListenerCalledForActiveDoc(
@@ -634,28 +772,30 @@ class SyncUnitTestHarness : Closeable {
         override fun verifyConflictHandlerCalledForActiveDoc(
             times: Int,
             expectedLocalConflictEvent: ChangeEvent<BsonDocument>?,
-            expectedRemoteConflictEvent: ChangeEvent<BsonDocument>?
+            expectedRemoteConflictEvent: CompactChangeEvent<BsonDocument>?
         ) {
             val localChangeEventArgumentCaptor = ArgumentCaptor.forClass(ChangeEvent::class.java)
-            val remoteChangeEventArgumentCaptor = ArgumentCaptor.forClass(ChangeEvent::class.java)
+            val remoteChangeEventArgumentCaptor = ArgumentCaptor.forClass(CompactChangeEvent::class.java)
 
             Mockito.verify(conflictHandler, times(times)).resolveConflict(
                 eq(testDocumentId),
                 localChangeEventArgumentCaptor.capture() as ChangeEvent<BsonDocument>?,
-                remoteChangeEventArgumentCaptor.capture() as ChangeEvent<BsonDocument>?)
+                remoteChangeEventArgumentCaptor.capture() as CompactChangeEvent<BsonDocument>?)
 
             if (expectedLocalConflictEvent != null) {
                 compareEvents(expectedLocalConflictEvent, localChangeEventArgumentCaptor.value as ChangeEvent<BsonDocument>)
             }
 
             if (expectedRemoteConflictEvent != null) {
-                compareEvents(expectedRemoteConflictEvent, remoteChangeEventArgumentCaptor.value as ChangeEvent<BsonDocument>)
+                compareEvents(expectedRemoteConflictEvent, remoteChangeEventArgumentCaptor.value as CompactChangeEvent<BsonDocument>)
             }
         }
 
         override fun verifyWatchFunctionCalled(times: Int, expectedArgs: Document) {
             Mockito.verify(service, times(times)).streamFunction(
-                eq("watch"), eq(Collections.singletonList(expectedArgs)), eq(ResultDecoders.changeEventDecoder(BsonDocumentCodec())))
+                eq("watch"),
+                eq(Collections.singletonList(expectedArgs.append("useCompactEvents", true))),
+                eq(ResultDecoders.compactChangeEventDecoder(BsonDocumentCodec())))
         }
 
         override fun verifyStartCalled(times: Int) {
@@ -692,6 +832,30 @@ class SyncUnitTestHarness : Closeable {
             `when`(collectionMock.deleteOne(any())).thenAnswer {
                 throw exception
             }
+        }
+
+        override fun mockFindOneResult(doc: BsonDocument?) {
+            `when`(collectionMock.findOne(any())).thenReturn(doc)
+        }
+
+        override fun mockFindResult(vararg docs: BsonDocument?) {
+            val remoteFindIterable = Mockito.mock(CoreRemoteFindIterable::class.java) as CoreRemoteFindIterable<BsonDocument>
+            Mockito.`when`(collectionMock.find(ArgumentMatchers.any())).thenReturn(remoteFindIterable)
+
+            val iterableSet = HashSet<BsonDocument>()
+            for (doc in docs) {
+                if (doc != null) {
+                    iterableSet.add(doc)
+                }
+            }
+
+            Mockito.`when`(remoteFindIterable.into<HashSet<BsonDocument>>(ArgumentMatchers.any())).thenReturn(iterableSet)
+            Mockito.`when`(remoteFindIterable.first()).thenReturn(docs[0])
+            this.mockFindOneResult(docs[0])
+        }
+
+        override fun clearFindOneMock() {
+            `when`(collectionMock.findOne(any())).thenReturn(null)
         }
 
         override fun close() {

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
@@ -232,7 +232,6 @@ class SyncUnitTestHarness : Closeable {
                     if (expectedDocumentId != null) {
                         Assert.assertEquals(expectedDocumentId, actualDocumentId)
                     }
-
                     emitErrorSemaphore?.release()
                 }
             }
@@ -539,7 +538,7 @@ class SyncUnitTestHarness : Closeable {
 
         override fun queueConsumableRemoteInsertEvent() {
             `when`(dataSynchronizer.getEventsForNamespace(any())).thenReturn(
-                mapOf(testDocument to ChangeEvents.compactChangeEventForLocalInsert(testDocument, true)),
+                mapOf(testDocument to ChangeEvents.compactChangeEventForLocalInsert(testDocument, false)),
                 mapOf())
         }
 
@@ -691,7 +690,7 @@ class SyncUnitTestHarness : Closeable {
         override fun queueConsumableRemoteDeleteEvent() {
             `when`(dataSynchronizer.getEventsForNamespace(any())).thenReturn(
                 mapOf(testDocument to ChangeEvents.compactChangeEventForLocalDelete(
-                    testDocumentId, true)),
+                    testDocumentId, false)),
                 mapOf())
         }
 
@@ -811,10 +810,14 @@ class SyncUnitTestHarness : Closeable {
 
         override fun mockUpdateResult(remoteUpdateResult: RemoteUpdateResult) {
             `when`(collectionMock.updateOne(any(), any())).thenReturn(remoteUpdateResult)
+            `when`(collectionMock.updateMany(any(), any())).thenReturn(remoteUpdateResult)
         }
 
         override fun mockUpdateException(exception: Exception) {
             `when`(collectionMock.updateOne(any(), any())).thenAnswer {
+                throw exception
+            }
+            `when`(collectionMock.updateMany(any(), any())).thenAnswer {
                 throw exception
             }
         }

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/SyncUnitTestHarness.kt
@@ -329,7 +329,6 @@ class SyncUnitTestHarness : Closeable {
         override val testDocumentHash: Long
             get() = HashUtils.hash(DataSynchronizer.sanitizeDocument(this.testDocument))
 
-
         var changeEventListener = newChangeEventListener()
             private set
         var conflictHandler = newConflictHandler()
@@ -585,7 +584,6 @@ class SyncUnitTestHarness : Closeable {
                             "v",
                             BsonInt64(documentVersionInfo.version.versionCounter - 1)
                         )
-
                     }
                     TestVersionState.SAME ->
                         documentVersionInfo.versionDoc
@@ -602,7 +600,7 @@ class SyncUnitTestHarness : Closeable {
                 }
             }
 
-            if(newVersion == null) {
+            if (newVersion == null) {
                 remoteUpdate.removedFields.add("__stitch_sync_version")
             } else {
                 remoteUpdate.updatedFields.append("__stitch_sync_version", newVersion)
@@ -618,7 +616,6 @@ class SyncUnitTestHarness : Closeable {
                 )),
                 mapOf())
         }
-
 
         override fun queueConsumableRemoteUpdateEvent(
             fromExpectedDoc: BsonDocument,
@@ -642,7 +639,6 @@ class SyncUnitTestHarness : Closeable {
             val newVersion: BsonDocument?
             val newDoc = fromExpectedDoc.clone()
 
-
             if (previousVersion != null) {
                 val documentVersionInfo = DocumentVersionInfo.fromVersionDoc(previousVersion.asDocument())
                 newVersion = when (versionState) {
@@ -657,7 +653,6 @@ class SyncUnitTestHarness : Closeable {
                             "v",
                             BsonInt64(documentVersionInfo.version.versionCounter - 1)
                         )
-
                     }
                     TestVersionState.SAME ->
                         documentVersionInfo.versionDoc
@@ -674,7 +669,7 @@ class SyncUnitTestHarness : Closeable {
                 }
             }
 
-            if(newVersion == null) {
+            if (newVersion == null) {
                 newDoc.remove("__stitch_sync_version")
             } else {
                 newDoc.append("__stitch_sync_version", newVersion)

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/UpdateDescriptionUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/UpdateDescriptionUnitTests.kt
@@ -6,6 +6,7 @@ import org.bson.BsonDocument
 import org.bson.BsonElement
 import org.bson.BsonInt32
 import org.bson.BsonString
+import org.bson.Document
 import org.bson.types.ObjectId
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -298,7 +299,7 @@ class UpdateDescriptionUnitTests {
         assertEquals(updatedFields, updateDoc["\$set"])
         assertEquals(removedFields, updateDoc["\$unset"]?.asDocument()?.entries?.map { it.key }?.toSet())
     }
-
+    
     private fun testDiff(
         collection: MongoCollection<BsonDocument>,
         beforeDocument: BsonDocument,

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/UpdateDescriptionUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/UpdateDescriptionUnitTests.kt
@@ -16,31 +16,6 @@ import java.lang.IllegalArgumentException
 
 class UpdateDescriptionUnitTests {
     @Test
-    fun testUpdateDescriptionApplyToDocument() {
-        val originalDoc = BsonDocument()
-            .append("a", BsonInt32(1))
-            .append("b", BsonInt32(2))
-            .append("c", BsonInt32(3))
-
-        val updateDescription = UpdateDescription(
-            BsonDocument()
-                .append("a", BsonInt32(11))
-                .append("d", BsonInt32(44)),
-            HashSet(hashSetOf("c"))
-        )
-
-        val newDoc = updateDescription.applyToBsonDocument(originalDoc)
-
-        assertEquals(
-            BsonDocument()
-                .append("a", BsonInt32(11))
-                .append("b", BsonInt32(2))
-                .append("d", BsonInt32(44)),
-            newDoc
-        )
-    }
-
-    @Test
     fun testUpdateDescriptionMerge() {
         val ud1 = UpdateDescription(BsonDocument("hi", BsonString("there")), setOf("meow", "bark"))
         val ud2 = UpdateDescription(BsonDocument("bye", BsonString("there")), setOf("prr", "woof"))

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/UpdateDescriptionUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/UpdateDescriptionUnitTests.kt
@@ -6,7 +6,6 @@ import org.bson.BsonDocument
 import org.bson.BsonElement
 import org.bson.BsonInt32
 import org.bson.BsonString
-import org.bson.conversions.Bson
 import org.bson.types.ObjectId
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull

--- a/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/UpdateDescriptionUnitTests.kt
+++ b/core/services/mongodb-remote/src/test/java/com/mongodb/stitch/core/services/mongodb/remote/sync/internal/UpdateDescriptionUnitTests.kt
@@ -6,7 +6,6 @@ import org.bson.BsonDocument
 import org.bson.BsonElement
 import org.bson.BsonInt32
 import org.bson.BsonString
-import org.bson.Document
 import org.bson.types.ObjectId
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -274,7 +273,7 @@ class UpdateDescriptionUnitTests {
         assertEquals(updatedFields, updateDoc["\$set"])
         assertEquals(removedFields, updateDoc["\$unset"]?.asDocument()?.entries?.map { it.key }?.toSet())
     }
-    
+
     private fun testDiff(
         collection: MongoCollection<BsonDocument>,
         beforeDocument: BsonDocument,

--- a/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
+++ b/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
@@ -855,6 +855,7 @@ class SyncIntTestProxy(private val syncTestRunner: SyncIntTestRunner) {
         // sync. assert that the desync'd document no longer exists locally
         streamAndSync()
         Assert.assertNull(coll.find(documentIdFilter(doc1Id)).firstOrNull())
+
         assertNoVersionFieldsInLocalColl(syncTestRunner.syncMethods())
     }
 
@@ -1863,6 +1864,12 @@ class SyncIntTestProxy(private val syncTestRunner: SyncIntTestRunner) {
 
     private fun waitForAllStreamsOpen() {
         while (!syncTestRunner.dataSynchronizer.areAllStreamsOpen()) {
+            if (syncTestRunner
+                    .dataSynchronizer
+                    .getSynchronizedDocuments(syncTestRunner.namespace).size > 0) {
+                println("there are no documents to watch, so the stream will never open")
+                break
+            }
             println("waiting for all streams to open before doing sync pass")
             Thread.sleep(1000)
         }

--- a/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
+++ b/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
@@ -69,7 +69,7 @@ class SyncIntTestProxy(private val syncTestRunner: SyncIntTestRunner) {
         val doc1Filter = Document("_id", doc1Id)
 
         // start watching it and always set the value to hello world in a conflict
-        syncOperations.configure(ConflictHandler { id: BsonValue, localEvent: ChangeEvent<Document>, remoteEvent: CompactChangeEvent<Document> ->
+        syncOperations.configure(ConflictHandler { id: BsonValue, localEvent: ChangeEvent<Document>, _: CompactChangeEvent<Document> ->
             // ensure that there is no version information on the documents in the conflict handler
             assertNoVersionFieldsInDoc(localEvent.fullDocument!!)
 
@@ -167,7 +167,7 @@ class SyncIntTestProxy(private val syncTestRunner: SyncIntTestRunner) {
         val doc1Id = BsonObjectId(doc.getObjectId("_id"))
         val doc1Filter = Document("_id", doc1Id)
 
-        coll.configure(ConflictHandler { _: BsonValue, localEvent: ChangeEvent<Document>, remoteEvent: CompactChangeEvent<Document> ->
+        coll.configure(ConflictHandler { _: BsonValue, localEvent: ChangeEvent<Document>, _: CompactChangeEvent<Document> ->
             val merged = Document(localEvent.fullDocument)
             val fetchedRemoteDoc = remoteColl
                 .find(Document("_id", localEvent.documentKey["_id"])).first()!!

--- a/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
+++ b/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
@@ -1866,7 +1866,7 @@ class SyncIntTestProxy(private val syncTestRunner: SyncIntTestRunner) {
         while (!syncTestRunner.dataSynchronizer.areAllStreamsOpen()) {
             if (syncTestRunner
                     .dataSynchronizer
-                    .getSynchronizedDocuments(syncTestRunner.namespace).size > 0) {
+                    .getSynchronizedDocuments(syncTestRunner.namespace).size == 0) {
                 println("there are no documents to watch, so the stream will never open")
                 break
             }

--- a/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
+++ b/core/testutils/src/main/java/com/mongodb/stitch/core/testutils/sync/SyncIntTestProxy.kt
@@ -1974,7 +1974,7 @@ class SyncIntTestProxy(private val syncTestRunner: SyncIntTestRunner) {
     private val failingConflictHandler = ConflictHandler { _: BsonValue, event1: ChangeEvent<Document>, event2: CompactChangeEvent<Document> ->
         val localEventDescription = when (event1.operationType == OperationType.DELETE) {
             true -> "delete"
-            false -> when(event1.operationType == OperationType.UPDATE) {
+            false -> when (event1.operationType == OperationType.UPDATE) {
                 true -> event1.updateDescription!!.toBsonDocument().toJson()
                 false -> event1.fullDocument!!.toJson()
             }


### PR DESCRIPTION
This is the big one. This updates the mobile sync codebase to use `watch` stream with compact events rather than traditional MongoDB change events. This required us to modify all code that operated on the assumption that `UPDATE` change events would have full documents.

This means that the DataSynchronizer now operates with `CompactChangeEvent`s when working with remote change events, and `ChangeEvent`s when working with local change events.

This meant changing all the unit tests and integration tests to use the new conflict handler, and to have remote events that are compact change events rather than full change events.

All unit tests and integration tests are passing locally, so any evergreen failure is likely to be an OOM error.

Notable Drive-Bys:
* The user-defined custom conflict handler now needs to return a `ConflictResolution` rather than a full document. This paves the way for defining richer conflict resolution cases in the future, and lets the data synchronizer figure out how to handle common cases like from remote or from local which can no longer be done with just the remote event.
    * This will be a major breaking change to the sync API
* REPLACE -> UPDATE coalescence now works by applying the UPDATE's update description to the REPLACE's full document rather than taking the UPDATE's full document.