### PR TITLE
STITCH-2945 don't wrap stream transport errors when they are Stitch service errors

### DIFF
--- a/core/sdk/src/main/java/com/mongodb/stitch/core/internal/net/BaseStitchRequestClient.java
+++ b/core/sdk/src/main/java/com/mongodb/stitch/core/internal/net/BaseStitchRequestClient.java
@@ -18,6 +18,7 @@ package com.mongodb.stitch.core.internal.net;
 
 import com.mongodb.stitch.core.StitchRequestErrorCode;
 import com.mongodb.stitch.core.StitchRequestException;
+import com.mongodb.stitch.core.StitchServiceException;
 import com.mongodb.stitch.core.internal.common.StitchError;
 
 public abstract class BaseStitchRequestClient implements StitchRequestClient {
@@ -57,7 +58,7 @@ public abstract class BaseStitchRequestClient implements StitchRequestClient {
     final Response response;
     try {
       response = transport.roundTrip(buildRequest(stitchReq, url));
-    } catch (Exception e) {
+    } catch (final Exception e) {
       throw new StitchRequestException(e, StitchRequestErrorCode.TRANSPORT_ERROR);
     }
 
@@ -69,7 +70,9 @@ public abstract class BaseStitchRequestClient implements StitchRequestClient {
   EventStream doStreamRequestUrl(final StitchRequest stitchReq, final String url) {
     try {
       return transport.stream(buildRequest(stitchReq, url));
-    } catch (Exception e) {
+    } catch (final StitchServiceException e) {
+      throw e;
+    } catch (final Exception e) {
       throw new StitchRequestException(e, StitchRequestErrorCode.TRANSPORT_ERROR);
     }
   }

--- a/core/sdk/src/main/java/com/mongodb/stitch/core/internal/net/OkHttpTransport.java
+++ b/core/sdk/src/main/java/com/mongodb/stitch/core/internal/net/OkHttpTransport.java
@@ -18,6 +18,7 @@ package com.mongodb.stitch.core.internal.net;
 
 import com.mongodb.stitch.core.StitchRequestErrorCode;
 import com.mongodb.stitch.core.StitchRequestException;
+import com.mongodb.stitch.core.StitchServiceException;
 import com.mongodb.stitch.core.internal.common.StitchError;
 
 import java.io.IOException;
@@ -118,7 +119,7 @@ public class OkHttpTransport implements Transport {
   }
 
   @Override
-  public EventStream stream(final Request request) throws IOException {
+  public EventStream stream(final Request request) throws IOException, StitchServiceException {
     request.getHeaders().put(
         com.mongodb.stitch.core.internal.net.Headers.CONTENT_TYPE,
         ContentTypes.TEXT_EVENT_STREAM);


### PR DESCRIPTION
streamFunction now only wraps errors that aren't StitchServiceExceptions. Drove-by some doc comments and nits.